### PR TITLE
3 add bottom navbar

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -171,6 +171,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -185,6 +186,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Flutter App</string>
+	<string>Qiita Client Yusei</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/screens/feed_page.dart
+++ b/lib/screens/feed_page.dart
@@ -10,20 +10,8 @@ class FeedPage extends StatefulWidget {
 class _FeedPageState extends State<FeedPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.white,
-          automaticallyImplyLeading : false,
-          title : const Text("Feed",
-            style: TextStyle(
-              fontFamily: 'Pacifico',
-              fontSize: 17.0,
-              color: Colors.black,
-            ),
-          ),
-
-        ),
-        body : const Center(
+    return const Scaffold(
+        body : Center(
           child: SizedBox(
             child: Text("フィードページ"),
           ),

--- a/lib/screens/feed_page.dart
+++ b/lib/screens/feed_page.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class FeedPage extends StatefulWidget {
+  const FeedPage({Key? key}) : super(key: key);
+
+  @override
+  State<FeedPage> createState() => _FeedPageState();
+}
+
+class _FeedPageState extends State<FeedPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          automaticallyImplyLeading : false,
+          title : const Text("Feed",
+            style: TextStyle(
+              fontFamily: 'Pacifico',
+              fontSize: 17.0,
+              color: Colors.black,
+            ),
+          ),
+
+        ),
+        body : const Center(
+          child: SizedBox(
+            child: Text("フィードページ"),
+          ),
+        )
+    );
+  }
+}

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/screens/feed_page.dart';
+import 'package:flutter_app/screens/tag_page.dart';
+import 'package:flutter_app/screens/my_page.dart';
+import 'package:flutter_app/screens/setting_page.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  List<Widget> display = [
+    const FeedPage(),
+    const TagPage(),
+    const MyPage(),
+    const SettingPage(),
+  ];
+
+  var _currentIndex = 0;
+  var _title = 'Feed';
+
+  void _onTap(int index) {
+    setState(() {
+      _currentIndex = index;
+
+      switch (index) {
+        case 0:
+          _title = 'Feed';
+          break;
+        case 1:
+          _title = 'Tags';
+          break;
+        case 2:
+          _title = 'MyPage';
+          break;
+        case 3:
+          _title = 'Settings';
+          break;
+      }
+    });
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        shadowColor: Colors.white.withOpacity(0.3),
+        automaticallyImplyLeading: false,
+        title: Text(
+          _title,
+          style: const TextStyle(
+            fontFamily: 'Pacifico',
+            fontSize: 17.0,
+            color: Colors.black,
+          ),
+        ),
+      ),
+      body: display[_currentIndex],
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+            border: Border(
+              top: BorderSide(
+                  width: 0.5,
+                  color: const Color(0x00000000).withOpacity(0.3),
+              ),
+            )),
+        child: BottomNavigationBar(
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.format_list_bulleted_outlined),
+              label: 'フィード',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.label_outline),
+              label: 'タグ',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.person_outline),
+              label: 'マイページ',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.settings_outlined),
+              label: '設定',
+            ),
+          ],
+          currentIndex: _currentIndex,
+          onTap: _onTap,
+          type: BottomNavigationBarType.fixed,
+          unselectedItemColor: const Color(0xFF828282),
+          selectedItemColor: const Color(0xFF74C13A),
+          unselectedFontSize: 10,
+          selectedFontSize: 10,
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/screens/my_page.dart
+++ b/lib/screens/my_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class MyPage extends StatefulWidget {
+  const MyPage({Key? key}) : super(key: key);
+
+  @override
+  State<MyPage> createState() => _MyPageState();
+}
+
+class _MyPageState extends State<MyPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          automaticallyImplyLeading : false,
+          title: const Text(
+            "MyPage",
+            style: TextStyle(
+              fontFamily: 'Pacifico',
+              fontSize: 17.0,
+              color: Colors.black,
+            ),
+          ),
+        ),
+        body: const Center(
+          child: SizedBox(
+            child: Text("マイページ"),
+          ),
+        ));
+  }
+}

--- a/lib/screens/my_page.dart
+++ b/lib/screens/my_page.dart
@@ -10,20 +10,8 @@ class MyPage extends StatefulWidget {
 class _MyPageState extends State<MyPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.white,
-          automaticallyImplyLeading : false,
-          title: const Text(
-            "MyPage",
-            style: TextStyle(
-              fontFamily: 'Pacifico',
-              fontSize: 17.0,
-              color: Colors.black,
-            ),
-          ),
-        ),
-        body: const Center(
+    return const Scaffold(
+        body: Center(
           child: SizedBox(
             child: Text("マイページ"),
           ),

--- a/lib/screens/setting_page.dart
+++ b/lib/screens/setting_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class SettingPage extends StatefulWidget {
+  const SettingPage({Key? key}) : super(key: key);
+
+  @override
+  State<SettingPage> createState() => _SettingPageState();
+}
+
+class _SettingPageState extends State<SettingPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          automaticallyImplyLeading : false,
+          title: const Text(
+            "Settings",
+            style: TextStyle(
+              fontFamily: 'Pacifico',
+              fontSize: 17.0,
+              color: Colors.black,
+            ),
+          ),
+        ),
+        body: const Center(
+          child: SizedBox(
+            child: Text("設定ページ"),
+          ),
+        ));
+  }
+}

--- a/lib/screens/setting_page.dart
+++ b/lib/screens/setting_page.dart
@@ -10,20 +10,8 @@ class SettingPage extends StatefulWidget {
 class _SettingPageState extends State<SettingPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.white,
-          automaticallyImplyLeading : false,
-          title: const Text(
-            "Settings",
-            style: TextStyle(
-              fontFamily: 'Pacifico',
-              fontSize: 17.0,
-              color: Colors.black,
-            ),
-          ),
-        ),
-        body: const Center(
+    return const Scaffold(
+        body: Center(
           child: SizedBox(
             child: Text("設定ページ"),
           ),

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class TagPage extends StatefulWidget {
+  const TagPage({Key? key}) : super(key: key);
+
+  @override
+  State<TagPage> createState() => _TagPageState();
+}
+
+class _TagPageState extends State<TagPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          automaticallyImplyLeading : false,
+          title: const Text(
+            "Tags",
+            style: TextStyle(
+              fontFamily: 'Pacifico',
+              fontSize: 17.0,
+              color: Colors.black,
+            ),
+          ),
+        ),
+        body: const Center(
+          child: SizedBox(
+            child: Text("タグページ"),
+          ),
+        ));
+  }
+}

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -10,20 +10,8 @@ class TagPage extends StatefulWidget {
 class _TagPageState extends State<TagPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.white,
-          automaticallyImplyLeading : false,
-          title: const Text(
-            "Tags",
-            style: TextStyle(
-              fontFamily: 'Pacifico',
-              fontSize: 17.0,
-              color: Colors.black,
-            ),
-          ),
-        ),
-        body: const Center(
+    return const Scaffold(
+        body: Center(
           child: SizedBox(
             child: Text("タグページ"),
           ),

--- a/lib/screens/top_page.dart
+++ b/lib/screens/top_page.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_app/screens/feed_page.dart';
 
 class TopPage extends StatefulWidget {
   const TopPage({Key? key}) : super(key: key);
@@ -83,7 +84,6 @@ class _TopPageState extends State<TopPage> {
                 width: deviceWidth * 0.85,
                 height: deviceHeight * 0.07,
                 child: ElevatedButton(
-                  onPressed: _loading,
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color(0xFF468300),
                     shadowColor: Colors.transparent,
@@ -99,6 +99,13 @@ class _TopPageState extends State<TopPage> {
                         letterSpacing: 0.75,
                         height: 1.14,
                       )),
+                  onPressed: () {
+                    // 3秒間ローディング
+                    _loading();
+                    // TODO ログイン処理を実装する
+                    //FeedPageに遷移
+                    _toFeed();
+                  },
                 ),
               ),
               SizedBox(
@@ -151,6 +158,13 @@ class _TopPageState extends State<TopPage> {
           imageOpacity = 0.2;
         });
       });
+    });
+  }
+
+  void _toFeed() {
+    Future.delayed(const Duration(seconds: 3), () {
+      Navigator.push(
+          context, MaterialPageRoute(builder: (context) => const FeedPage()));
     });
   }
 }

--- a/lib/screens/top_page.dart
+++ b/lib/screens/top_page.dart
@@ -101,10 +101,8 @@ class _TopPageState extends State<TopPage> {
                       )),
                   onPressed: () {
                     // 3秒間ローディング
-                    _loading();
+                    _loadingToFeed();
                     // TODO ログイン処理を実装する
-                    //FeedPageに遷移
-                    _toFeed();
                   },
                 ),
               ),
@@ -113,7 +111,9 @@ class _TopPageState extends State<TopPage> {
                 height: deviceHeight * 0.1,
                 child: Center(
                   child: TextButton(
-                    onPressed: () {},
+                    onPressed: () {
+                      _toFeed();
+                    },
                     child: const Text(
                       'ログインせずに利用する',
                       style: TextStyle(
@@ -147,7 +147,7 @@ class _TopPageState extends State<TopPage> {
     );
   }
 
-  void _loading() {
+  void _loadingToFeed() {
     setState(() {
       isLoading = true;
       imageOpacity = 0.3;
@@ -156,15 +156,14 @@ class _TopPageState extends State<TopPage> {
         setState(() {
           isLoading = false;
           imageOpacity = 0.2;
+          _toFeed();
         });
       });
     });
   }
 
   void _toFeed() {
-    Future.delayed(const Duration(seconds: 3), () {
       Navigator.push(
           context, MaterialPageRoute(builder: (context) => const HomePage()));
-    });
   }
 }

--- a/lib/screens/top_page.dart
+++ b/lib/screens/top_page.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_app/screens/feed_page.dart';
+import 'package:flutter_app/screens/home_page.dart';
 
 class TopPage extends StatefulWidget {
   const TopPage({Key? key}) : super(key: key);
@@ -164,7 +164,7 @@ class _TopPageState extends State<TopPage> {
   void _toFeed() {
     Future.delayed(const Duration(seconds: 3), () {
       Navigator.push(
-          context, MaterialPageRoute(builder: (context) => const FeedPage()));
+          context, MaterialPageRoute(builder: (context) => const HomePage()));
     });
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,56 +5,64 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   english_words:
     dependency: "direct main"
     description:
       name: english_words
-      url: "https://pub.dartlang.org"
+      sha256: "6a7ef6473a97bd8571b6b641d006a6e58a7c67e65fb6f3d6d1151cb46b0e983c"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -66,7 +74,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -74,39 +83,52 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   sky_engine:
@@ -118,50 +140,57 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
 sdks:
   dart: ">=2.18.6 <3.0.0"


### PR DESCRIPTION
【やったこと（実装内容）】

**（top_page.dart）**　

> 対象コミット
> d6f51859515818a07a328948ae239a87c91ec4c
> -  ログインボタンを押すと、3s間のローディング後、フィード画面へ遷移する処理を追加
> - 「ログインせずに利用する」を押すと、即座にフィード画面へ遷移する処理を追加

**（home_page.dart）**　
> 対象コミット
> 59e7b19a49ecb91f0702e949da24c4a6dd23e2bd
> -  共通利用するためのAppBarを追加
> - ボトムナビゲーションの追加（フィード画面、タグ画面、マイページ、設定画面への遷移処理を追記）


**（その他）**
- 遷移先のサンプル画面（フィード画面、タグ画面、マイページ、設定画面）を追加
- アプリ名を Qiita Client Yusei に変更

<hr>
<br>

※下記画像はiOS simulator のiPhone SEでプレビューした様子です。

↓ **起動時**
<img src="https://user-images.githubusercontent.com/78660150/222180584-ba2b6592-b34d-44d7-9bcc-ea25bad48b12.png" width="220px">

<br>


↓ **ログイン を押した場合**
<img src="https://user-images.githubusercontent.com/78660150/222185272-ce6c8ee3-5e3f-4a50-9621-c6280f704f65.gif" width="220px">

※3s間のローディングの後に画面が切り替わります。

<br>


↓ **ログインせずに利用する** を押した場合
<img src="https://user-images.githubusercontent.com/78660150/222185757-8032bf78-e336-46be-8d48-4d8a773c5432.gif" width="220px">

※即座に画面が切り替わります。
