### PR TITLE
5 create tag screen

### DIFF
--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-
-import '../view_model/tag_view_model.dart';
+import '../model/tag.dart';
 
 class QiitaApiService {
   // Qiita APIのエンドポイントURL

--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../view_model/tag_view_model.dart';
+
 class QiitaApiService {
   // Qiita APIのエンドポイントURL
   final String apiUrl = 'https://qiita.com/api/v2/items';
@@ -73,4 +75,37 @@ class QiitaApiService {
     }
     return [];
   }
+
+
+  Future<List<Tag>> fetchTagList(int page, int i) async {
+    // QiitaのAPIからタグ一覧を取得
+    final response = await http.get(
+        Uri.parse('https://qiita.com/api/v2/tags?page=$page&per_page=20&sort=count'),
+      headers: {
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body);
+      if (data == null) {
+        return [];
+      }
+      final tags = data.map<Tag>((tagData) {
+        final iconUrl = tagData['icon_url'];
+        return Tag(
+          name: tagData['id'] ?? '',
+          iconUrl: iconUrl ?? 'https://via.placeholder.com/150?text=No+Image',
+          followersCount: tagData['followers_count'] ?? 0,
+          itemsCount: tagData['items_count'] ?? 0,
+        );
+      }).toList();
+      return tags;
+    } else {
+      throw Exception('Failed to load tags');
+    }
+  }
+
+
+
 }

--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -68,7 +68,7 @@ class QiitaApiService {
             return newItems;
           }
         } catch (e) {
-            print('fetchQiitaItems error: $e');
+          print('fetchQiitaItems error: $e');
           return [];
         }
       }
@@ -76,11 +76,11 @@ class QiitaApiService {
     return [];
   }
 
-
   Future<List<Tag>> fetchTagList(int page, int i) async {
     // QiitaのAPIからタグ一覧を取得
     final response = await http.get(
-        Uri.parse('https://qiita.com/api/v2/tags?page=$page&per_page=20&sort=count'),
+      Uri.parse(
+          'https://qiita.com/api/v2/tags?page=$page&per_page=20&sort=count'),
       headers: {
         'Authorization': 'Bearer $accessToken',
       },
@@ -105,7 +105,4 @@ class QiitaApiService {
       throw Exception('Failed to load tags');
     }
   }
-
-
-
 }

--- a/lib/components/custom_btn.dart
+++ b/lib/components/custom_btn.dart
@@ -16,7 +16,7 @@ class CustomButton extends StatefulWidget {
   final bool btnLoading;
 
   @override
-  _CustomButtonState createState() => _CustomButtonState();
+  State<CustomButton> createState() => _CustomButtonState();
 }
 
 class _CustomButtonState extends State<CustomButton> {

--- a/lib/components/loading_widget.dart
+++ b/lib/components/loading_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class LoadingWidget extends StatelessWidget {
+  const LoadingWidget({
+    Key? key,
+    this.radius = 22.0,
+    this.color = Colors.blue,
+    this.isCircle = false,
+  }) : super(key: key);
+
+  final double radius;
+  final Color color;
+  final bool isCircle;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget indicator;
+
+    if (isCircle) {
+      indicator = CircularProgressIndicator(
+        strokeWidth: 2.0,
+        color: color,
+      );
+    } else {
+      indicator = CupertinoActivityIndicator(
+        radius: radius,
+        color: color,
+        animating: true,
+      );
+    }
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: indicator,
+      ),
+    );
+  }
+}

--- a/lib/components/tag_card.dart
+++ b/lib/components/tag_card.dart
@@ -1,0 +1,183 @@
+// import 'package:flutter/material.dart';
+// import 'package:flutter_app/screens/tag_detail_list_page.dart';
+// import 'package:provider/provider.dart';
+// import '../model/tag.dart';
+// import '../view_model/tag_view_model.dart';
+// import 'loading_widget.dart';
+
+//
+// class TagCard extends StatelessWidget {
+//   final Tag tag;
+//
+//   const TagCard({Key? key, required this.tag}) : super(key: key);
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return Card(
+//       shape: RoundedRectangleBorder(
+//         side: const BorderSide(
+//           color: Color(0xFFE0E0E0),
+//           width: 1.0,
+//         ),
+//         borderRadius: BorderRadius.circular(8.0),
+//       ),
+//       child: InkWell(
+//         onTap: () {
+//           Navigator.push(
+//             context,
+//             MaterialPageRoute(
+//               builder: (context) => TagDetailListPage(tag: tag),
+//             ),
+//           );
+//         },
+//         child: Consumer<TagViewModel>(
+//           builder: (context, model, child) {
+//             if (model.isLoading && model.tags.isEmpty) {
+//               return const LoadingWidget(isCircle: true);
+//             } else if (model.tags.isNotEmpty && model.tags.last == tag) {
+//               if (model.isLoading) {
+//                 return const LoadingWidget(isCircle: true);
+//               } else if (!model.isLastPage) {
+//                 return const LoadingWidget(isCircle: true);
+//               }
+//             }
+//             return SizedBox(
+//               child: Column(
+//                 mainAxisAlignment: MainAxisAlignment.center,
+//                 crossAxisAlignment: CrossAxisAlignment.center,
+//                 children: [
+//                   Image.network(
+//                     tag.iconUrl,
+//                     width: 38,
+//                     height: 38,
+//                   ),
+//                   const SizedBox(height: 8),
+//                   Text(
+//                     tag.name,
+//                     style: const TextStyle(
+//                       fontFamily: 'Noto Sans JP',
+//                       fontSize: 14,
+//                       fontWeight: FontWeight.w500,
+//                       height: 20 / 14,
+//                       letterSpacing: 0.25,
+//                       color: Color(0xFF333333),
+//                     ),
+//                     textAlign: TextAlign.center,
+//                   ),
+//                   const SizedBox(height: 8),
+//                   Text(
+//                     '記事件数：${tag.itemsCount}',
+//                     style: const TextStyle(
+//                       fontFamily: 'Noto Sans JP',
+//                       fontSize: 12,
+//                       fontWeight: FontWeight.w500,
+//                       height: 1,
+//                       letterSpacing: 0,
+//                       color: Color(0xFF828282),
+//                     ),
+//                     textAlign: TextAlign.center,
+//                   ),
+//                   Text(
+//                     'フォロワー数：${tag.followersCount}',
+//                     style: const TextStyle(
+//                       fontFamily: 'Noto Sans JP',
+//                       fontSize: 12,
+//                       fontWeight: FontWeight.w500,
+//                       height: 1,
+//                       letterSpacing: 0,
+//                       color: Color(0xFF828282),
+//                     ),
+//                     textAlign: TextAlign.center,
+//                   ),
+//                 ],
+//               ),
+//             );
+//           },
+//         ),
+//       ),
+//     );
+//   }
+// }
+import 'package:flutter/material.dart';
+import 'package:flutter_app/screens/tag_detail_list_page.dart';
+import 'package:provider/provider.dart';
+import '../model/tag.dart';
+import '../view_model/tag_view_model.dart';
+import 'loading_widget.dart';
+import 'tag_card_text.dart';
+
+class TagCard extends StatelessWidget {
+  final Tag tag;
+
+  const TagCard({Key? key, required this.tag}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      shape: RoundedRectangleBorder(
+        side: const BorderSide(
+          color: Color(0xFFE0E0E0),
+          width: 1.0,
+        ),
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      child: InkWell(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => TagDetailListPage(tag: tag),
+            ),
+          );
+        },
+        child: Consumer<TagViewModel>(
+          builder: (context, model, child) {
+            if (model.isLoading && model.tags.isEmpty ||
+                model.tags.isNotEmpty &&
+                    model.tags.last == tag &&
+                    model.isLoading ||
+                model.tags.isNotEmpty &&
+                    !model.isLastPage &&
+                    model.tags.last == tag) {
+              return const LoadingWidget(isCircle: true);
+            }
+
+            return SizedBox(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Image.network(
+                    tag.iconUrl,
+                    width: 38,
+                    height: 38,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    tag.name,
+                    style: const TextStyle(
+                      fontFamily: 'Noto Sans JP',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      height: 20 / 14,
+                      letterSpacing: 0.25,
+                      color: Color(0xFF333333),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  Column(
+                    children: [
+                      TagCardText(label: '記事件数：', tag: tag),
+                      TagCardText(label: 'フォロワー数：', tag: tag),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/tag_card_text.dart
+++ b/lib/components/tag_card_text.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import '../model/tag.dart';
+
+class TagCardText extends StatelessWidget {
+  final String label;
+  final Tag tag;
+
+  const TagCardText({Key? key, required this.label, required this.tag})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    const TextStyle style = TextStyle(
+      fontFamily: 'Noto Sans JP',
+      fontSize: 12,
+      fontWeight: FontWeight.w500,
+      height: 1,
+      letterSpacing: 0,
+      color: Color(0xFF828282),
+    );
+
+    return Text(
+      '$label${label == '記事件数：' ? tag.itemsCount : tag.followersCount}',
+      style: style,
+      textAlign: TextAlign.center,
+    );
+  }
+}

--- a/lib/model/tag.dart
+++ b/lib/model/tag.dart
@@ -1,0 +1,14 @@
+
+class Tag {
+  final String name;
+  final String iconUrl;
+  final int followersCount;
+  final int itemsCount;
+
+  Tag({
+    required this.name,
+    required this.iconUrl,
+    required this.followersCount,
+    required this.itemsCount,
+  });
+}

--- a/lib/screens/tag_detail_list_page.dart
+++ b/lib/screens/tag_detail_list_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../view_model/tag_view_model.dart';
+
+class TagDetailListPage extends StatelessWidget {
+  final Tag tag;
+
+  const TagDetailListPage({Key? key, required this.tag}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(tag.name),
+      ),
+      body: const Center(
+        child: Text('タグ詳細ページ'),
+      ),
+    );
+  }
+}

--- a/lib/screens/tag_detail_list_page.dart
+++ b/lib/screens/tag_detail_list_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../view_model/tag_view_model.dart';
+import '../model/tag.dart';
 
 class TagDetailListPage extends StatelessWidget {
   final Tag tag;

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -1,20 +1,284 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_app/screens/tag_detail_list_page.dart';
+import 'package:provider/provider.dart';
+import '../components/no_internet_widget.dart';
+import '../main.dart';
+import '../util/connection_status.dart';
+import '../view_model/tag_view_model.dart';
 
 class TagPage extends StatefulWidget {
-  const TagPage({Key? key,}) : super(key: key);
+  const TagPage({
+    Key? key,
+  }) : super(key: key);
 
   @override
   State<TagPage> createState() => _TagPageState();
 }
 
 class _TagPageState extends State<TagPage> {
+  final TagViewModel tagViewModel = TagViewModel();
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(Duration.zero, () {
+      ConnectionStatus.checkConnectivity().then((isConnected) async {
+        if (isConnected) {
+          await tagViewModel.fetchTags();
+        } else {
+          setState(() {
+            connectionStatus.interNetConnected = false;
+          });
+        }
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-        body: Center(
-          child: SizedBox(
-            child: Text("タグページ"),
-          ),
-        ));
+    final double itemHeight = MediaQuery.of(context).size.height / 2.5;
+    final double itemWidth = MediaQuery.of(context).size.width / 2;
+    final screenWidth = MediaQuery.of(context).size.width;
+    int crossAxisCount = 2;
+    if (screenWidth > 768) {
+      // タブレット以上の場合は3列
+      crossAxisCount = 3;
+    }
+    return Scaffold(
+      appBar: connectionStatus.interNetConnected
+          ? null
+          : AppBar(
+              backgroundColor: Colors.white,
+              automaticallyImplyLeading: false,
+              shadowColor: Colors.white.withOpacity(0.3),
+            ),
+      body: ChangeNotifierProvider(
+        create: (_) => tagViewModel,
+        child: Consumer<TagViewModel>(
+          builder: (context, model, child) {
+            if (model.isLoading && model.tags.isEmpty) {
+              //初期表示のインディケーター
+              return const Center(
+                child: CupertinoActivityIndicator(
+                  radius: 22,
+                  color: Color(0xFF6A717D),
+                ),
+              );
+            } else if (!connectionStatus.interNetConnected &&
+                model.tags.isEmpty) {
+              return NoInternetWidget(
+                onPressed: () async {
+                  // ネットワーク接続状態を確認する
+                  bool isConnected = await ConnectionStatus.checkConnectivity();
+                  if (isConnected) {
+                    setState(() {
+                      connectionStatus.interNetConnected = true;
+                    });
+                    model.fetchTags();
+                  } else {
+                    // ネットワークに接続されていない場合はエラーメッセージを表示する
+                    setState(() {
+                      connectionStatus.interNetConnected = false;
+                    });
+                  }
+                },
+              );
+            } else {
+              return Stack(
+                children: [
+                  Visibility(
+                    visible: model.tags.isNotEmpty,
+                    child: NotificationListener<ScrollNotification>(
+                      onNotification: (ScrollNotification scrollInfo) {
+                        if (!model.isLastPage &&
+                            !model.isLoading &&
+                            scrollInfo.metrics.pixels >=
+                                scrollInfo.metrics.maxScrollExtent + 10) {
+                          model.fetchTags();
+                        }
+
+                        if (Theme.of(context).platform ==
+                            TargetPlatform.android) {
+                          if (scrollInfo.metrics.pixels ==
+                              scrollInfo.metrics.maxScrollExtent) {
+                            model.fetchTags();
+                          }
+                        }
+                        return false;
+                      },
+                      child: Column(
+                        children: [
+                          // Padding(
+                          //   padding: const EdgeInsets.fromLTRB(0, 30, 0, 10),
+                          //   child: Visibility(
+                          //     visible: model.isLoading,
+                          //     child: const Center(
+                          //       child: CupertinoActivityIndicator(
+                          //         radius: 18,
+                          //         color: Color(0xFF6A717D),
+                          //       ),
+                          //     ),
+                          //   ),
+                          // ),
+                          Expanded(
+                            child: GridView.builder(
+                              shrinkWrap: true,
+                              reverse: true,
+                              itemCount: model.tags.isNotEmpty
+                                  ? model.tags.length +
+                                      (model.isLastPage ? 0 : 1)
+                                  : 1,
+                              itemBuilder: (BuildContext context, int index) {
+                                if (index == model.tags.length) {
+                                  return Padding(
+                                    padding: EdgeInsets.fromLTRB(MediaQuery.of(context).size.width / 2, 0, 0, 0),
+                                    child: SizedBox(
+                                      width:MediaQuery.of(context).size.width,
+                                      child: const Center(
+                                        child: CupertinoActivityIndicator(
+                                          radius: 18,
+                                          color: Color(0xFF6A717D),
+                                        ),
+                                      ),
+                                    ),
+                                  );
+                                } else {
+                                  return SizedBox(
+                                    width: itemWidth,
+                                    height: itemHeight,
+                                    child: TagCard(tag: model.tags[index]),
+                                  );
+                                }
+                              },
+                              gridDelegate:
+                                  SliverGridDelegateWithFixedCrossAxisCount(
+                                childAspectRatio: 1.0,
+                                crossAxisSpacing: 3,
+                                mainAxisSpacing: 3,
+                                crossAxisCount: crossAxisCount,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  //追加ローディング中は表示しない
+                  Visibility(
+                    visible: model.isLoading && model.tags.isEmpty,
+                    child: const Center(
+                      child: CupertinoActivityIndicator(
+                        radius: 22,
+                        color: Color(0xFF6A717D),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class TagCard extends StatelessWidget {
+  final Tag tag;
+
+  const TagCard({Key? key, required this.tag}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: InkWell(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => TagDetailListPage(tag: tag),
+            ),
+          );
+        },
+        child: Consumer<TagViewModel>(
+          builder: (context, model, child) {
+            if (model.isLoading && model.tags.isEmpty) {
+              return const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: CircularProgressIndicator(),
+                ),
+              );
+            } else if (model.tags.isNotEmpty && model.tags.last == tag) {
+              if (model.isLoading) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              } else if (!model.isLastPage) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: CircularProgressIndicator(),
+                  ),
+                );
+              }
+            }
+            return Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Image.network(
+                  tag.iconUrl,
+                  width: 38,
+                  height: 38,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  tag.name,
+                  style: const TextStyle(
+                    fontFamily: 'Noto Sans JP',
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    height: 20 / 14,
+                    letterSpacing: 0.25,
+                    color: Color(0xFF333333),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '記事件数：${tag.itemsCount}',
+                  style: const TextStyle(
+                    fontFamily: 'Noto Sans JP',
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    height: 12 / 12,
+                    letterSpacing: 0,
+                    color: Color(0xFF828282),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                Text(
+                  'フォロワー数：${tag.followersCount}',
+                  style: const TextStyle(
+                    fontFamily: 'Noto Sans JP',
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    height: 12 / 12,
+                    letterSpacing: 0,
+                    color: Color(0xFF828282),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
   }
 }

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -48,16 +48,12 @@ class _TagPageState extends State<TagPage> {
     return Scaffold(
       appBar: connectionStatus.interNetConnected
           ? null
-          : AppBar(
-              backgroundColor: Colors.white,
-              automaticallyImplyLeading: false,
-              shadowColor: Colors.white.withOpacity(0.3),
-            ),
+          : null,
       body: ChangeNotifierProvider(
         create: (_) => tagViewModel,
         child: Consumer<TagViewModel>(
           builder: (context, model, child) {
-            if (model.isLoading && model.tags.isEmpty) {
+            if (model.isLoading && model.tags.isEmpty && connectionStatus.interNetConnected) {
               //初期表示のインディケーター
               return const Center(
                 child: CupertinoActivityIndicator(

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -108,49 +108,50 @@ class _TagPageState extends State<TagPage> {
                         return false;
                       },
                       child: Padding(
-                        padding: const EdgeInsets.only(left:17, right:17),
+                        padding: const EdgeInsets.only(left: 17, right: 17),
                         child: Column(
                           children: [
                             Expanded(
-
-                                child: GridView.builder(
-                                  shrinkWrap: true,
-                                  reverse: true,
-                                  itemCount: model.tags.isNotEmpty
-                                      ? model.tags.length +
-                                          (model.isLastPage ? 0 : 1)
-                                      : 1,
-                                  itemBuilder: (BuildContext context, int index) {
-                                    if (index == model.tags.length) {
-                                      return Padding(
-                                        padding: EdgeInsets.fromLTRB(paddingLeft, 0, 0, 10),
-                                        child: SizedBox(
-                                          width:MediaQuery.of(context).size.width,
-                                          child: const Center(
-                                            child: CupertinoActivityIndicator(
-                                              radius: 18,
-                                              color: Color(0xFF6A717D),
-                                            ),
+                              child: GridView.builder(
+                                shrinkWrap: true,
+                                reverse: true,
+                                itemCount: model.tags.isNotEmpty
+                                    ? model.tags.length +
+                                        (model.isLastPage ? 0 : 1)
+                                    : 1,
+                                itemBuilder: (BuildContext context, int index) {
+                                  if (index == model.tags.length) {
+                                    return Padding(
+                                      padding: EdgeInsets.fromLTRB(
+                                          paddingLeft, 0, 0, 10),
+                                      child: SizedBox(
+                                        width:
+                                            MediaQuery.of(context).size.width,
+                                        child: const Center(
+                                          child: CupertinoActivityIndicator(
+                                            radius: 18,
+                                            color: Color(0xFF6A717D),
                                           ),
                                         ),
-                                      );
-                                    } else {
-                                      return SizedBox(
-                                        // width: itemWidth,
-                                        // height: itemHeight,
-                                        child: TagCard(tag: model.tags[index]),
-                                      );
-                                    }
-                                  },
-                                  gridDelegate:
-                                      SliverGridDelegateWithFixedCrossAxisCount(
-                                    childAspectRatio: 1.0,
-                                    crossAxisSpacing: 8,
-                                    mainAxisSpacing: 8,
-                                    crossAxisCount: crossAxisCount,
-                                  ),
+                                      ),
+                                    );
+                                  } else {
+                                    return SizedBox(
+                                      // width: itemWidth,
+                                      // height: itemHeight,
+                                      child: TagCard(tag: model.tags[index]),
+                                    );
+                                  }
+                                },
+                                gridDelegate:
+                                    SliverGridDelegateWithFixedCrossAxisCount(
+                                  childAspectRatio: 1.0,
+                                  crossAxisSpacing: 8,
+                                  mainAxisSpacing: 8,
+                                  crossAxisCount: crossAxisCount,
                                 ),
                               ),
+                            ),
                           ],
                         ),
                       ),

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -6,6 +6,7 @@ import '../components/no_internet_widget.dart';
 import '../main.dart';
 import '../util/connection_status.dart';
 import '../view_model/tag_view_model.dart';
+import '../model/tag.dart';
 
 class TagPage extends StatefulWidget {
   const TagPage({
@@ -46,9 +47,6 @@ class _TagPageState extends State<TagPage> {
       paddingLeft = MediaQuery.of(context).size.width / 2.1;
     }
     return Scaffold(
-      appBar: connectionStatus.interNetConnected
-          ? null
-          : null,
       body: ChangeNotifierProvider(
         create: (_) => tagViewModel,
         child: Consumer<TagViewModel>(
@@ -110,7 +108,6 @@ class _TagPageState extends State<TagPage> {
                             Expanded(
                               child: GridView.builder(
                                 shrinkWrap: true,
-                                reverse: true,
                                 itemCount: model.tags.isNotEmpty
                                     ? model.tags.length +
                                         (model.isLastPage ? 0 : 1)

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -37,8 +37,6 @@ class _TagPageState extends State<TagPage> {
 
   @override
   Widget build(BuildContext context) {
-    final double itemHeight = MediaQuery.of(context).size.height / 2.5;
-    final double itemWidth = MediaQuery.of(context).size.width / 2;
     final screenWidth = MediaQuery.of(context).size.width;
     int crossAxisCount = 2;
     if (screenWidth > 768) {
@@ -107,60 +105,52 @@ class _TagPageState extends State<TagPage> {
                         }
                         return false;
                       },
-                      child: Column(
-                        children: [
-                          // Padding(
-                          //   padding: const EdgeInsets.fromLTRB(0, 30, 0, 10),
-                          //   child: Visibility(
-                          //     visible: model.isLoading,
-                          //     child: const Center(
-                          //       child: CupertinoActivityIndicator(
-                          //         radius: 18,
-                          //         color: Color(0xFF6A717D),
-                          //       ),
-                          //     ),
-                          //   ),
-                          // ),
-                          Expanded(
-                            child: GridView.builder(
-                              shrinkWrap: true,
-                              reverse: true,
-                              itemCount: model.tags.isNotEmpty
-                                  ? model.tags.length +
-                                      (model.isLastPage ? 0 : 1)
-                                  : 1,
-                              itemBuilder: (BuildContext context, int index) {
-                                if (index == model.tags.length) {
-                                  return Padding(
-                                    padding: EdgeInsets.fromLTRB(MediaQuery.of(context).size.width / 2, 0, 0, 0),
-                                    child: SizedBox(
-                                      width:MediaQuery.of(context).size.width,
-                                      child: const Center(
-                                        child: CupertinoActivityIndicator(
-                                          radius: 18,
-                                          color: Color(0xFF6A717D),
+                      child: Padding(
+                        padding: const EdgeInsets.only(left:17, right:17),
+                        child: Column(
+                          children: [
+                            Expanded(
+
+                                child: GridView.builder(
+                                  shrinkWrap: true,
+                                  reverse: true,
+                                  itemCount: model.tags.isNotEmpty
+                                      ? model.tags.length +
+                                          (model.isLastPage ? 0 : 1)
+                                      : 1,
+                                  itemBuilder: (BuildContext context, int index) {
+                                    if (index == model.tags.length) {
+                                      return Padding(
+                                        padding: EdgeInsets.fromLTRB(MediaQuery.of(context).size.width / 2.2, 0, 0, 0),
+                                        child: SizedBox(
+                                          width:MediaQuery.of(context).size.width,
+                                          child: const Center(
+                                            child: CupertinoActivityIndicator(
+                                              radius: 18,
+                                              color: Color(0xFF6A717D),
+                                            ),
+                                          ),
                                         ),
-                                      ),
-                                    ),
-                                  );
-                                } else {
-                                  return SizedBox(
-                                    width: itemWidth,
-                                    height: itemHeight,
-                                    child: TagCard(tag: model.tags[index]),
-                                  );
-                                }
-                              },
-                              gridDelegate:
-                                  SliverGridDelegateWithFixedCrossAxisCount(
-                                childAspectRatio: 1.0,
-                                crossAxisSpacing: 3,
-                                mainAxisSpacing: 3,
-                                crossAxisCount: crossAxisCount,
+                                      );
+                                    } else {
+                                      return SizedBox(
+                                        // width: itemWidth,
+                                        // height: itemHeight,
+                                        child: TagCard(tag: model.tags[index]),
+                                      );
+                                    }
+                                  },
+                                  gridDelegate:
+                                      SliverGridDelegateWithFixedCrossAxisCount(
+                                    childAspectRatio: 1.0,
+                                    crossAxisSpacing: 8,
+                                    mainAxisSpacing: 8,
+                                    crossAxisCount: crossAxisCount,
+                                  ),
+                                ),
                               ),
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -192,6 +182,13 @@ class TagCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
+      shape: RoundedRectangleBorder(
+        side: const BorderSide(
+          color: Color(0xFFE0E0E0),
+          width: 1.0,
+        ),
+        borderRadius: BorderRadius.circular(8.0),
+      ),
       child: InkWell(
         onTap: () {
           Navigator.push(

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -38,10 +38,12 @@ class _TagPageState extends State<TagPage> {
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
+    double paddingLeft = screenWidth / 2.2;
     int crossAxisCount = 2;
     if (screenWidth > 768) {
       // タブレット以上の場合は3列
       crossAxisCount = 3;
+      paddingLeft = MediaQuery.of(context).size.width / 2.1;
     }
     return Scaffold(
       appBar: connectionStatus.interNetConnected
@@ -92,7 +94,7 @@ class _TagPageState extends State<TagPage> {
                         if (!model.isLastPage &&
                             !model.isLoading &&
                             scrollInfo.metrics.pixels >=
-                                scrollInfo.metrics.maxScrollExtent + 10) {
+                                scrollInfo.metrics.maxScrollExtent + 5) {
                           model.fetchTags();
                         }
 
@@ -121,7 +123,7 @@ class _TagPageState extends State<TagPage> {
                                   itemBuilder: (BuildContext context, int index) {
                                     if (index == model.tags.length) {
                                       return Padding(
-                                        padding: EdgeInsets.fromLTRB(MediaQuery.of(context).size.width / 2.2, 0, 0, 0),
+                                        padding: EdgeInsets.fromLTRB(paddingLeft, 0, 0, 10),
                                         child: SizedBox(
                                           width:MediaQuery.of(context).size.width,
                                           child: const Center(
@@ -224,54 +226,56 @@ class TagCard extends StatelessWidget {
                 );
               }
             }
-            return Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Image.network(
-                  tag.iconUrl,
-                  width: 38,
-                  height: 38,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  tag.name,
-                  style: const TextStyle(
-                    fontFamily: 'Noto Sans JP',
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
-                    height: 20 / 14,
-                    letterSpacing: 0.25,
-                    color: Color(0xFF333333),
+            return SizedBox(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Image.network(
+                    tag.iconUrl,
+                    width: 38,
+                    height: 38,
                   ),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  '記事件数：${tag.itemsCount}',
-                  style: const TextStyle(
-                    fontFamily: 'Noto Sans JP',
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    height: 12 / 12,
-                    letterSpacing: 0,
-                    color: Color(0xFF828282),
+                  const SizedBox(height: 8),
+                  Text(
+                    tag.name,
+                    style: const TextStyle(
+                      fontFamily: 'Noto Sans JP',
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      height: 20 / 14,
+                      letterSpacing: 0.25,
+                      color: Color(0xFF333333),
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
-                ),
-                Text(
-                  'フォロワー数：${tag.followersCount}',
-                  style: const TextStyle(
-                    fontFamily: 'Noto Sans JP',
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    height: 12 / 12,
-                    letterSpacing: 0,
-                    color: Color(0xFF828282),
+                  const SizedBox(height: 8),
+                  Text(
+                    '記事件数：${tag.itemsCount}',
+                    style: const TextStyle(
+                      fontFamily: 'Noto Sans JP',
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                      height: 12 / 12,
+                      letterSpacing: 0,
+                      color: Color(0xFF828282),
+                    ),
+                    textAlign: TextAlign.center,
                   ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
+                  Text(
+                    'フォロワー数：${tag.followersCount}',
+                    style: const TextStyle(
+                      fontFamily: 'Noto Sans JP',
+                      fontSize: 12,
+                      fontWeight: FontWeight.w500,
+                      height: 12 / 12,
+                      letterSpacing: 0,
+                      color: Color(0xFF828282),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             );
           },
         ),

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -1,17 +1,14 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_app/screens/tag_detail_list_page.dart';
 import 'package:provider/provider.dart';
+import '../components/loading_widget.dart';
 import '../components/no_internet_widget.dart';
+import '../components/tag_card.dart';
 import '../main.dart';
 import '../util/connection_status.dart';
 import '../view_model/tag_view_model.dart';
-import '../model/tag.dart';
 
 class TagPage extends StatefulWidget {
-  const TagPage({
-    Key? key,
-  }) : super(key: key);
+  const TagPage({Key? key}) : super(key: key);
 
   @override
   State<TagPage> createState() => _TagPageState();
@@ -23,254 +20,120 @@ class _TagPageState extends State<TagPage> {
   @override
   void initState() {
     super.initState();
-    Future.delayed(Duration.zero, () {
-      ConnectionStatus.checkConnectivity().then((isConnected) async {
+    Future(() async {
+      await ConnectionStatus.checkConnectivity().then((isConnected) {
         if (isConnected) {
-          await tagViewModel.fetchTags();
+          tagViewModel.fetchTags();
         } else {
-          setState(() {
-            connectionStatus.interNetConnected = false;
-          });
+          connectionStatus.interNetConnected = false;
         }
       });
     });
   }
 
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildInitialLoadingWidget() {
+    return const LoadingWidget(radius: 22.0, color: Color(0xFF6A717D));
+  }
+
+  Widget _buildNoInternetWidget() {
+    return NoInternetWidget(
+      onPressed: () async {
+        if (await ConnectionStatus.checkConnectivity()) {
+          connectionStatus.interNetConnected = true;
+          tagViewModel.fetchTags();
+        } else {
+          connectionStatus.interNetConnected = false;
+        }
+      },
+    );
+  }
+
+  Widget _buildLoadingWidget() {
+    return const LoadingWidget(radius: 18.0, color: Color(0xFF6A717D));
+  }
+
+  Widget _buildTagsGridView(TagViewModel model) {
     final screenWidth = MediaQuery.of(context).size.width;
-    double paddingLeft = screenWidth / 2.2;
-    int crossAxisCount = 2;
-    if (screenWidth > 768) {
-      // タブレット以上の場合は3列
-      crossAxisCount = 3;
-      paddingLeft = MediaQuery.of(context).size.width / 2.1;
-    }
-    return Scaffold(
-      body: ChangeNotifierProvider(
-        create: (_) => tagViewModel,
-        child: Consumer<TagViewModel>(
-          builder: (context, model, child) {
-            if (model.isLoading && model.tags.isEmpty && connectionStatus.interNetConnected) {
-              //初期表示のインディケーター
-              return const Center(
-                child: CupertinoActivityIndicator(
-                  radius: 22,
-                  color: Color(0xFF6A717D),
+    final crossAxisCount = screenWidth > 768 ? 3 : 2;
+    final paddingLeft = screenWidth > 768
+        ? MediaQuery.of(context).size.width / 2.1
+        : screenWidth / 2.38;
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: (scrollInfo) {
+        if (!model.isLastPage &&
+            !model.isLoading &&
+            scrollInfo.metrics.pixels >=
+                scrollInfo.metrics.maxScrollExtent + 5) {
+          model.fetchTags();
+        }
+
+        if (Theme.of(context).platform == TargetPlatform.android) {
+          if (scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent) {
+            model.fetchTags();
+          }
+        }
+        return false;
+      },
+      child: Padding(
+        padding: const EdgeInsets.only(left: 17, right: 17),
+        child: GridView.builder(
+          shrinkWrap: true,
+          itemCount: model.tags.isNotEmpty
+              ? model.tags.length + (model.isLastPage ? 0 : 1)
+              : 1,
+          itemBuilder: (BuildContext context, int index) {
+            if (index == model.tags.length) {
+              return Padding(
+                padding: EdgeInsets.fromLTRB(paddingLeft, 0, 0, 10),
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width,
+                  child: _buildLoadingWidget(),
                 ),
               );
+            } else {
+              return TagCard(tag: model.tags[index]);
+            }
+          },
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            childAspectRatio: 1.0,
+            crossAxisSpacing: 8,
+            mainAxisSpacing: 8,
+            crossAxisCount: crossAxisCount,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ChangeNotifierProvider.value(
+        value: tagViewModel,
+        child: Consumer<TagViewModel>(
+          builder: (context, model, child) {
+            if (model.isLoading &&
+                model.tags.isEmpty &&
+                connectionStatus.interNetConnected) {
+              return _buildInitialLoadingWidget();
             } else if (!connectionStatus.interNetConnected &&
                 model.tags.isEmpty) {
-              return NoInternetWidget(
-                onPressed: () async {
-                  // ネットワーク接続状態を確認する
-                  bool isConnected = await ConnectionStatus.checkConnectivity();
-                  if (isConnected) {
-                    setState(() {
-                      connectionStatus.interNetConnected = true;
-                    });
-                    model.fetchTags();
-                  } else {
-                    // ネットワークに接続されていない場合はエラーメッセージを表示する
-                    setState(() {
-                      connectionStatus.interNetConnected = false;
-                    });
-                  }
-                },
-              );
+              return _buildNoInternetWidget();
             } else {
               return Stack(
                 children: [
                   Visibility(
                     visible: model.tags.isNotEmpty,
-                    child: NotificationListener<ScrollNotification>(
-                      onNotification: (ScrollNotification scrollInfo) {
-                        if (!model.isLastPage &&
-                            !model.isLoading &&
-                            scrollInfo.metrics.pixels >=
-                                scrollInfo.metrics.maxScrollExtent + 5) {
-                          model.fetchTags();
-                        }
-
-                        if (Theme.of(context).platform ==
-                            TargetPlatform.android) {
-                          if (scrollInfo.metrics.pixels ==
-                              scrollInfo.metrics.maxScrollExtent) {
-                            model.fetchTags();
-                          }
-                        }
-                        return false;
-                      },
-                      child: Padding(
-                        padding: const EdgeInsets.only(left: 17, right: 17),
-                        child: Column(
-                          children: [
-                            Expanded(
-                              child: GridView.builder(
-                                shrinkWrap: true,
-                                itemCount: model.tags.isNotEmpty
-                                    ? model.tags.length +
-                                        (model.isLastPage ? 0 : 1)
-                                    : 1,
-                                itemBuilder: (BuildContext context, int index) {
-                                  if (index == model.tags.length) {
-                                    return Padding(
-                                      padding: EdgeInsets.fromLTRB(
-                                          paddingLeft, 0, 0, 10),
-                                      child: SizedBox(
-                                        width:
-                                            MediaQuery.of(context).size.width,
-                                        child: const Center(
-                                          child: CupertinoActivityIndicator(
-                                            radius: 18,
-                                            color: Color(0xFF6A717D),
-                                          ),
-                                        ),
-                                      ),
-                                    );
-                                  } else {
-                                    return SizedBox(
-                                      // width: itemWidth,
-                                      // height: itemHeight,
-                                      child: TagCard(tag: model.tags[index]),
-                                    );
-                                  }
-                                },
-                                gridDelegate:
-                                    SliverGridDelegateWithFixedCrossAxisCount(
-                                  childAspectRatio: 1.0,
-                                  crossAxisSpacing: 8,
-                                  mainAxisSpacing: 8,
-                                  crossAxisCount: crossAxisCount,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
+                    child: _buildTagsGridView(model),
                   ),
-                  //追加ローディング中は表示しない
                   Visibility(
                     visible: model.isLoading && model.tags.isEmpty,
-                    child: const Center(
-                      child: CupertinoActivityIndicator(
-                        radius: 22,
-                        color: Color(0xFF6A717D),
-                      ),
-                    ),
+                    child: _buildInitialLoadingWidget(),
                   ),
                 ],
               );
             }
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class TagCard extends StatelessWidget {
-  final Tag tag;
-
-  const TagCard({Key? key, required this.tag}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      shape: RoundedRectangleBorder(
-        side: const BorderSide(
-          color: Color(0xFFE0E0E0),
-          width: 1.0,
-        ),
-        borderRadius: BorderRadius.circular(8.0),
-      ),
-      child: InkWell(
-        onTap: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => TagDetailListPage(tag: tag),
-            ),
-          );
-        },
-        child: Consumer<TagViewModel>(
-          builder: (context, model, child) {
-            if (model.isLoading && model.tags.isEmpty) {
-              return const Center(
-                child: Padding(
-                  padding: EdgeInsets.all(16),
-                  child: CircularProgressIndicator(),
-                ),
-              );
-            } else if (model.tags.isNotEmpty && model.tags.last == tag) {
-              if (model.isLoading) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: CircularProgressIndicator(),
-                  ),
-                );
-              } else if (!model.isLastPage) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: CircularProgressIndicator(),
-                  ),
-                );
-              }
-            }
-            return SizedBox(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Image.network(
-                    tag.iconUrl,
-                    width: 38,
-                    height: 38,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    tag.name,
-                    style: const TextStyle(
-                      fontFamily: 'Noto Sans JP',
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
-                      height: 20 / 14,
-                      letterSpacing: 0.25,
-                      color: Color(0xFF333333),
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    '記事件数：${tag.itemsCount}',
-                    style: const TextStyle(
-                      fontFamily: 'Noto Sans JP',
-                      fontSize: 12,
-                      fontWeight: FontWeight.w500,
-                      height: 12 / 12,
-                      letterSpacing: 0,
-                      color: Color(0xFF828282),
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                  Text(
-                    'フォロワー数：${tag.followersCount}',
-                    style: const TextStyle(
-                      fontFamily: 'Noto Sans JP',
-                      fontSize: 12,
-                      fontWeight: FontWeight.w500,
-                      height: 12 / 12,
-                      letterSpacing: 0,
-                      color: Color(0xFF828282),
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            );
           },
         ),
       ),

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -1,19 +1,6 @@
 import '../api/qiita_api_service.dart';
 import 'package:flutter/material.dart';
-
-class Tag {
-  final String name;
-  final String iconUrl;
-  final int followersCount;
-  final int itemsCount;
-
-  Tag({
-    required this.name,
-    required this.iconUrl,
-    required this.followersCount,
-    required this.itemsCount,
-  });
-}
+import '../model/tag.dart';
 
 class TagViewModel extends ChangeNotifier {
   final List<Tag> _tags = [];

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -1,0 +1,77 @@
+import '../api/qiita_api_service.dart';
+import 'package:flutter/material.dart';
+
+class Tag {
+  final String name;
+  final String iconUrl;
+  final int followersCount;
+  final int itemsCount;
+
+  Tag({
+    required this.name,
+    required this.iconUrl,
+    required this.followersCount,
+    required this.itemsCount,
+  });
+}
+
+class TagViewModel extends ChangeNotifier {
+  final List<Tag> _tags = [];
+  bool _isLoading = true;
+  int _columnCount = 2;
+  final ScrollController _scrollController = ScrollController();
+  final QiitaApiService _qiitaApiService = QiitaApiService();
+  bool _isLastPage = false;
+  final int _perPage = 20;
+
+  List<Tag> get tags => _tags;
+
+  bool get isLoading => _isLoading;
+
+  int get columnCount => _columnCount;
+
+  ScrollController get scrollController => _scrollController;
+
+  bool get isLastPage => _isLastPage;
+
+  Future<void> fetchTags() async {
+    if (_isLastPage) {
+      return;
+    }
+
+    if (!isLastPage) {
+      _isLoading = true;
+      notifyListeners();
+    }
+
+    // タグ一覧を取得
+    List<Tag> newTags = await _qiitaApiService.fetchTagList(
+        _perPage, _tags.length ~/ _perPage + 1);
+
+    if (newTags.isEmpty) {
+      _isLastPage = true;
+    }
+
+    // 取得したタグを既存のタグリストに追加
+    _tags.addAll(newTags);
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  void updateColumnCount(double width) {
+    if (width < 600) {
+      _columnCount = 2;
+    } else if (width < 900) {
+      _columnCount = 3;
+    } else {
+      _columnCount = 4;
+    }
+    notifyListeners();
+  }
+
+  void handleScrollEnd() {
+    if (_scrollController.position.extentAfter == 0) {
+      fetchTags();
+    }
+  }
+}

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -30,8 +30,6 @@ class TagViewModel extends ChangeNotifier {
 
   int get columnCount => _columnCount;
 
-  ScrollController get scrollController => _scrollController;
-
   bool get isLastPage => _isLastPage;
 
   Future<void> fetchTags() async {
@@ -67,11 +65,5 @@ class TagViewModel extends ChangeNotifier {
       _columnCount = 4;
     }
     notifyListeners();
-  }
-
-  void handleScrollEnd() {
-    if (_scrollController.position.extentAfter == 0) {
-      fetchTags();
-    }
   }
 }

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -6,7 +6,6 @@ class TagViewModel extends ChangeNotifier {
   final List<Tag> _tags = [];
   bool _isLoading = true;
   int _columnCount = 2;
-  final ScrollController _scrollController = ScrollController();
   final QiitaApiService _qiitaApiService = QiitaApiService();
   bool _isLastPage = false;
   final int _perPage = 20;


### PR DESCRIPTION

**Tag画面の実装**を行いました。
レビューいただけますと幸いです。


## ①実装内容（全体）

※以下のチェックボックスにチェックがついているものは、iOS・Androidともに動作確認ができた機能です。

- [x] **タグに紐づいたデータ表示→完了**

<br>

- [x] **タグをタップして遷移→完了**
<br>

- [x] **ページネーション実装→完了**


> ↓プレビュー画面（iPhone 14）
> <img src="https://user-images.githubusercontent.com/78660150/225706378-69a1b68d-f355-4a0f-abcf-9b2b9a5e704f.gif" width="280px">

<br>

> ↓プレビュー画面（iPad Air）
> <img src="https://user-images.githubusercontent.com/78660150/225706919-96b69dfa-7fd4-4551-b97a-43f51f8418c3.gif" width="380px">

<br>


## ②実装内容（詳細）

### **lib/api/qiita_api_service.dart**
 - タグデータを取得するためのメソッド（`fetchTagList`）を追記

<br>

### **lib/screens/tag_detail_list_page.dart**
- 遷移先として、設定したページ（タップされたタグのタイトルを取得し、AppBarに表示）

<br>

### **lib/screens/tag_page.dart**
- タグ一覧をGridViewで表示するWidgetを追記
※インターネット未接続の場合はNoInternetWidgetを表示する。

> ↓プレビュー画面（Android）
> <video src="https://user-images.githubusercontent.com/78660150/225715287-e5d71eb4-1979-4273-9efc-62c00a80b11b.webm"></video>

<br>

### **lib/view_model/tag_view_model.dart**
- tag_page.dartの状態を管理するためのクラスや、メソッドを定義。

<br>