### PR TITLE
6 create tag detail screen

### DIFF
--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -5,7 +5,7 @@ import '../model/tag.dart';
 
 class QiitaApiService {
   // Qiita APIのエンドポイントURL
-  final String apiUrl = 'https://qiita.com/api/v2/items';
+  String apiUrl = 'https://qiita.com/api/v2/items';
 
   // Qiita APIのアクセストークン
   // TODO 認証系実装時に削除する
@@ -19,12 +19,17 @@ class QiitaApiService {
     required int perPage,
     required String searchKeyword,
     required bool isLastPage,
+    required String pageName,
   }) async {
     if (!isLastPage) {
+      if (pageName == "tag_detail_list") {
+        apiUrl = "https://qiita.com/api/v2/tags/$searchKeyword/items";
+      }
+
       String url = '$apiUrl?per_page=$perPage&page=$currentPage';
 
       // 検索キーワードがある場合、URLに追加する
-      if (searchKeyword.isNotEmpty) {
+      if (searchKeyword.isNotEmpty && pageName != "tag_detail_list") {
         url += '&query=$searchKeyword';
       }
 
@@ -44,10 +49,11 @@ class QiitaApiService {
               'Authorization': 'Bearer $accessToken',
             },
           );
+          print(url);
 
           // レスポンスをパースし、記事のリストを作成する
           final List<dynamic> newItems = json.decode(response.body);
-
+          print(newItems);
           // キャッシュに記事を追加する
           cache[url] = newItems;
 
@@ -77,6 +83,7 @@ class QiitaApiService {
 
   Future<List<Tag>> fetchTagList(int page, int i) async {
     // QiitaのAPIからタグ一覧を取得
+    // TODO currentPageを$pageに代入する
     final response = await http.get(
       Uri.parse(
           'https://qiita.com/api/v2/tags?page=$page&per_page=20&sort=count'),

--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -26,7 +26,7 @@ class QiitaApiService {
         apiUrl = "https://qiita.com/api/v2/tags/$searchKeyword/items";
       }
 
-      String url = '$apiUrl?per_page=$perPage&page=$currentPage';
+      String url = '$apiUrl?page=$currentPage&per_page=$perPage';
 
       // 検索キーワードがある場合、URLに追加する
       if (searchKeyword.isNotEmpty && pageName != "tag_detail_list") {
@@ -53,7 +53,7 @@ class QiitaApiService {
 
           // レスポンスをパースし、記事のリストを作成する
           final List<dynamic> newItems = json.decode(response.body);
-          print(newItems);
+          // print(newItems);
           // キャッシュに記事を追加する
           cache[url] = newItems;
 
@@ -81,17 +81,17 @@ class QiitaApiService {
     return [];
   }
 
-  Future<List<Tag>> fetchTagList(int page, int i) async {
+  Future<List<Tag>> fetchTagList(int currentPage, int perPage) async {
     // QiitaのAPIからタグ一覧を取得
-    // TODO currentPageを$pageに代入する
+
     final response = await http.get(
       Uri.parse(
-          'https://qiita.com/api/v2/tags?page=$page&per_page=20&sort=count'),
+          'https://qiita.com/api/v2/tags?page=$currentPage&per_page=$perPage&sort=count'),
       headers: {
         'Authorization': 'Bearer $accessToken',
       },
     );
-
+    print('https://qiita.com/api/v2/tags?page=$currentPage&per_page=$perPage&sort=count');
     if (response.statusCode == 200) {
       final data = jsonDecode(response.body);
       if (data == null) {

--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -29,7 +29,7 @@ class QiitaApiService {
       String url = '$apiUrl?page=$currentPage&per_page=$perPage';
 
       // 検索キーワードがある場合、URLに追加する
-      if (searchKeyword.isNotEmpty && pageName != "tag_detail_list") {
+      if (searchKeyword.isNotEmpty && pageName == "feed") {
         url += '&query=$searchKeyword';
       }
 

--- a/lib/components/article_list.dart
+++ b/lib/components/article_list.dart
@@ -32,9 +32,9 @@ class ArticleList extends StatelessWidget {
     return RefreshIndicator(
       onRefresh: () async {
         if (pageName == "feed") {
-          feedViewModel.pullQiitaItems();
+          feedViewModel.pullQiitaItems(pageName);
         } else {
-          await feedViewModel.searchQiitaItems(tag!.name);
+          await feedViewModel.searchQiitaItems(tag!.name, "tag_detail_list");
         }
       },
       child: Column(

--- a/lib/components/article_list.dart
+++ b/lib/components/article_list.dart
@@ -25,8 +25,11 @@ class ArticleList extends StatelessWidget {
   Widget build(BuildContext context) {
     final item = feedViewModel.itemsList[index];
     final user = item['user'];
-    final formattedDate =
-        DateFormat('yyyy/MM/dd').format(DateTime.parse(item['created_at']));
+    // 日本標準時に設定
+    final formattedDate = DateFormat('yyyy/MM/dd').format(
+        DateTime.parse(item['created_at'])
+            .toUtc()
+            .add(const Duration(hours: 9)));
     final likeCount = item['likes_count'];
 
     return RefreshIndicator(

--- a/lib/components/article_list.dart
+++ b/lib/components/article_list.dart
@@ -1,0 +1,98 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../model/tag.dart';
+import '../view_model/feed_view_model.dart';
+import '../components/web_view_screen.dart';
+import '../components/custom_modal.dart';
+
+class ArticleList extends StatelessWidget {
+  final FeedViewModel feedViewModel;
+  final Tag? tag;
+  final List<dynamic> itemsList;
+  final int index;
+  final String pageName;
+
+  const ArticleList(
+      {super.key,
+      required this.feedViewModel,
+      required this.tag,
+      required this.itemsList,
+      required this.index,
+      required this.pageName});
+
+  @override
+  Widget build(BuildContext context) {
+    final item = feedViewModel.itemsList[index];
+    final user = item['user'];
+    final formattedDate =
+        DateFormat('yyyy/MM/dd').format(DateTime.parse(item['created_at']));
+    final likeCount = item['likes_count'];
+
+    return RefreshIndicator(
+      onRefresh: () async {
+        if (pageName == "feed") {
+          feedViewModel.pullQiitaItems();
+        } else {
+          await feedViewModel.searchQiitaItems(tag!.name);
+        }
+      },
+      child: Column(
+        children: [
+          ListTile(
+            leading: CachedNetworkImage(
+              imageBuilder: (context, imageProvider) => Container(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  image: DecorationImage(
+                    image: imageProvider,
+                  ),
+                ),
+              ),
+              placeholder: (context, url) => const CircularProgressIndicator(),
+              errorWidget: (context, url, error) => const Icon(Icons.person),
+              imageUrl: user['profile_image_url'],
+              width: 38,
+              height: 38,
+            ),
+            title: Padding(
+              padding: const EdgeInsets.fromLTRB(0, 8, 16, 0),
+              child: Text(
+                item['title'],
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                    fontWeight: FontWeight.w500,
+                    fontSize: 14,
+                    letterSpacing: 0.25,
+                    color: Color(0xFF333333)),
+              ),
+            ),
+            subtitle: Padding(
+              padding: const EdgeInsets.fromLTRB(0, 0, 16, 8),
+              child: Text(
+                '@${user['id']} 投稿日: $formattedDate いいね数: $likeCount',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                    fontWeight: FontWeight.w500,
+                    fontSize: 12,
+                    height: 2.0,
+                    color: Color(0xFF828282)),
+              ),
+            ),
+            onTap: () async {
+              await customModal(context, WebViewPage(urlString: item['url']));
+            },
+          ),
+          const Divider(
+            color: Color(0xFFB2B2B2),
+            thickness: 0.5,
+            height: 0,
+            indent: 80,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -58,9 +58,9 @@ class _ArticleDetailListBodyContentState
     if (await ConnectionStatus.checkConnectivity()) {
       connectionStatus.interNetConnected = true;
       if (pageName == "tag_detail_list") {
-        await model.searchQiitaItems(tag!.name);
+        await model.searchQiitaItems(tag!.name, "tag_detail_list");
       } else {
-        await model.pullQiitaItems();
+        await model.pullQiitaItems(pageName);
       }
     } else {
       connectionStatus.interNetConnected = false;
@@ -72,19 +72,7 @@ class _ArticleDetailListBodyContentState
     return Consumer<FeedViewModel>(
       builder: (context, model, child) {
         Widget content;
-        if (model.isLoading && model.itemsList.isEmpty) {
-          content = const LoadingWidget(radius: 22.0, color: Color(0xFF6A717D));
-        } else if (!connectionStatus.interNetConnected &&
-            model.itemsList.isEmpty) {
-          content = NoInternetWidget(
-            onPressed: () async {
-              await fetchItems(
-                  context.read<FeedViewModel>(), widget.pageName, widget.tag);
-            },
-          );
-        } else {
-          content = _buildContent(model);
-        }
+        content = _buildContent(model);
         return content;
       },
     );
@@ -113,14 +101,13 @@ class _ArticleDetailListBodyContentState
                   !model.isLoading &&
                   scrollInfo.metrics.pixels >=
                       scrollInfo.metrics.maxScrollExtent + 10) {
-                model.pullQiitaItems();
+                model.pullQiitaItems(widget.pageName);
               }
 
-              if (Theme.of(context).platform == TargetPlatform.android) {
-                if (scrollInfo.metrics.pixels ==
-                    scrollInfo.metrics.maxScrollExtent) {
-                  model.pullQiitaItems();
-                }
+              if (Theme.of(context).platform == TargetPlatform.android &&
+                  scrollInfo.metrics.atEdge &&
+                  scrollInfo.metrics.pixels > 0) {
+                model.pullQiitaItems(widget.pageName);
               }
               return false;
             },

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/components/article_list.dart';
+import 'package:flutter_app/components/no_internet_widget.dart';
+import 'package:flutter_app/model/tag.dart';
+import 'package:flutter_app/util/connection_status.dart';
+import 'package:flutter_app/view_model/feed_view_model.dart';
+import 'package:provider/provider.dart';
+
+// import '../api/qiita_api_service.dart';
+import '../main.dart';
+import 'loading_widget.dart';
+
+class ArticleDetailListBody extends StatelessWidget {
+  final Tag? tag;
+  final String pageName;
+
+  const ArticleDetailListBody({Key? key, this.tag, required this.pageName})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => FeedViewModel(),
+      child: _ArticleDetailListBodyContent(tag: tag, pageName: pageName),
+    );
+  }
+}
+
+class _ArticleDetailListBodyContent extends StatefulWidget {
+  final Tag? tag;
+  final String pageName;
+
+  const _ArticleDetailListBodyContent(
+      {Key? key, this.tag, required this.pageName})
+      : super(key: key);
+
+  @override
+  State<_ArticleDetailListBodyContent> createState() =>
+      _ArticleDetailListBodyContentState();
+}
+
+class _ArticleDetailListBodyContentState
+    extends State<_ArticleDetailListBodyContent> {
+  late final FeedViewModel _feedViewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    // QiitaApiService().isMyPage = false;
+    // _feedViewModel = context.read<FeedViewModel>();
+    _feedViewModel = Provider.of<FeedViewModel>(context, listen: false);
+    Future.delayed(Duration.zero, () {
+      ConnectionStatus.checkConnectivity().then((isConnected) async {
+        if (isConnected) {
+          if (widget.pageName == "feed") {
+            _feedViewModel.pullQiitaItems();
+          } else {
+            await _feedViewModel.searchQiitaItems(widget.tag!.name);
+          }
+        } else {
+          connectionStatus.interNetConnected = false;
+        }
+      });
+      // _feedViewModel.firstLoading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<FeedViewModel>(
+      builder: (context, model, child) {
+        Widget content;
+        if (model.isLoading && model.itemsList.isEmpty) {
+          content = const LoadingWidget(radius: 22.0, color: Color(0xFF6A717D));
+        } else if (!connectionStatus.interNetConnected &&
+            model.itemsList.isEmpty) {
+          content = NoInternetWidget(
+            onPressed: () async {
+              bool isConnected = await ConnectionStatus.checkConnectivity();
+              if (isConnected) {
+                connectionStatus.interNetConnected = true;
+                if (widget.pageName == "feed") {
+                  model.pullQiitaItems();
+                } else {
+                  await model.searchQiitaItems(widget.tag!.name);
+                }
+              } else {
+                connectionStatus.interNetConnected = false;
+              }
+            },
+          );
+        } else {
+          content = _buildContent(model);
+        }
+        return content;
+      },
+    );
+  }
+
+  Widget _buildContent(FeedViewModel model) {
+    if (model.isLoading && model.itemsList.isEmpty) {
+      return const LoadingWidget(radius: 22.0, color: Color(0xFF6A717D));
+    }
+
+    if (!connectionStatus.interNetConnected && model.itemsList.isEmpty) {
+      return NoInternetWidget(
+        onPressed: () async {
+          bool isConnected = await ConnectionStatus.checkConnectivity();
+          if (isConnected) {
+            connectionStatus.interNetConnected = true;
+            if (widget.pageName == "feed") {
+              model.pullQiitaItems();
+            } else {
+              await model.searchQiitaItems(widget.tag!.name);
+            }
+          } else {
+            connectionStatus.interNetConnected = false;
+          }
+        },
+      );
+    }
+
+    return Stack(
+      children: [
+        if (model.itemsList.isNotEmpty)
+          NotificationListener<ScrollNotification>(
+            onNotification: (ScrollNotification scrollInfo) {
+              if (!model.isLastPage &&
+                  !model.isLoading &&
+                  scrollInfo.metrics.pixels >=
+                      scrollInfo.metrics.maxScrollExtent + 10) {
+                model.pullQiitaItems();
+              }
+
+              if (Theme.of(context).platform == TargetPlatform.android) {
+                if (scrollInfo.metrics.pixels ==
+                    scrollInfo.metrics.maxScrollExtent) {
+                  model.pullQiitaItems();
+                }
+              }
+              return false;
+            },
+            child: Column(
+              children: [
+                Visibility(
+                  //タグ詳細ページでのみ表示
+                  visible: widget.pageName == "tag_detail_list",
+                  child: Container(
+                    color: const Color(0xFFf2f2f2),
+                    alignment: Alignment.centerLeft,
+                    child: Container(
+                      margin: const EdgeInsets.only(
+                          left: 12.0, top: 8.0, bottom: 8.0),
+                      child: const Text(
+                        '投稿記事',
+                        style: TextStyle(
+                          fontSize: 12.0,
+                          color: Color(0xFF828282),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: model.itemsList.isNotEmpty
+                        ? model.itemsList.length + (model.isLastPage ? 0 : 1)
+                        : 1,
+                    itemBuilder: (BuildContext context, int index) {
+                      final padding =
+                          Theme.of(context).platform == TargetPlatform.android
+                              ? const EdgeInsets.fromLTRB(0, 40, 0, 30)
+                              : const EdgeInsets.fromLTRB(0, 10, 0, 20);
+                      if (index == model.itemsList.length) {
+                        return Center(
+                          child: Padding(
+                            padding: padding,
+                            child: model.isLoading
+                                ? const LoadingWidget(
+                                    radius: 18.0, color: Color(0xFF6A717D))
+                                : Container(),
+                          ),
+                        );
+                      } else {
+                        return ArticleList(
+                          feedViewModel: _feedViewModel,
+                          index: index,
+                          tag: widget.tag,
+                          itemsList: model.itemsList,
+                          pageName: widget.pageName,
+                        );
+                      }
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        if (widget.pageName == "feed" &&
+            !(model.itemsList.isNotEmpty) &&
+            !model.isLoading &&
+            !model.firstLoading &&
+            connectionStatus.interNetConnected)
+          _buildNoResultWidget(),
+        if (model.isLoading && model.itemsList.isEmpty)
+          const LoadingWidget(radius: 22.0, color: Color(0xFF6A717D)),
+        if (!connectionStatus.interNetConnected && model.itemsList.isEmpty)
+          Container(),
+      ],
+    );
+  }
+
+  Widget _buildNoResultWidget() {
+    return SingleChildScrollView(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 227),
+          child: Column(
+            children: const [
+              Icon(Icons.search_off, size: 48),
+              Text(
+                '検索にマッチする記事はありませんでした',
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: Color(0xFF333333),
+                  letterSpacing: -0.24,
+                ),
+              ),
+              SizedBox(height: 17),
+              Text(
+                '検索条件を変えるなどして、再度検索してください。',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Color(0xFF828282),
+                  height: 2,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -99,15 +99,14 @@ class _ArticleDetailListBodyContentState
             onNotification: (ScrollNotification scrollInfo) {
               if (!model.isLastPage &&
                   !model.isLoading &&
-                  scrollInfo.metrics.pixels >=
-                      scrollInfo.metrics.maxScrollExtent + 10) {
+                  ((Theme.of(context).platform == TargetPlatform.android &&
+                          scrollInfo.metrics.atEdge &&
+                          scrollInfo.metrics.pixels > 0) ||
+                      (Theme.of(context).platform == TargetPlatform.iOS &&
+                          scrollInfo.metrics.pixels >=
+                              scrollInfo.metrics.maxScrollExtent + 5))) {
                 model.pullQiitaItems(widget.pageName);
-              }
-
-              if (Theme.of(context).platform == TargetPlatform.android &&
-                  scrollInfo.metrics.atEdge &&
-                  scrollInfo.metrics.pixels > 0) {
-                model.pullQiitaItems(widget.pageName);
+                print("${Theme.of(context).platform} scroll");
               }
               return false;
             },

--- a/lib/components/custom_modal.dart
+++ b/lib/components/custom_modal.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+Future<void> customModal(BuildContext context, Widget child) async {
+  await showModalBottomSheet(
+    backgroundColor: Colors.transparent,
+    context: context,
+    isScrollControlled: true,
+    builder: (context) => SizedBox(
+      height: MediaQuery.of(context).size.height * 0.9,
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.only(bottom: 11),
+            alignment: Alignment.bottomCenter,
+            height: 59,
+            decoration: const BoxDecoration(
+              color: Color.fromRGBO(249, 249, 249, 1),
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(10),
+                topRight: Radius.circular(10),
+              ),
+            ),
+            child: const Text(
+              'Article',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontFamily: 'Pacifico', fontSize: 17),
+            ),
+          ),
+          Expanded(child: child),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/components/web_view_screen.dart
+++ b/lib/components/web_view_screen.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-
+// TODO 4系で書き直してみる
 class WebViewPage extends StatefulWidget {
   const WebViewPage({Key? key, required this.urlString}) : super(key: key);
   final String urlString;

--- a/lib/screens/feed_page.dart
+++ b/lib/screens/feed_page.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../components/loading_widget.dart';
 import '../main.dart';
 import '../util/connection_status.dart';
 import '../components/no_internet_widget.dart';
@@ -222,12 +222,10 @@ class _FeedPageState extends State<FeedPage> {
           builder: (context, model, child) {
             if (model.isLoading && model.itemsList.isEmpty) {
               return const Center(
-                child: CupertinoActivityIndicator(
-                  radius: 22,
-                  color: Color(0xFF6A717D),
-                ),
+                child: LoadingWidget(radius: 22.0, color: Color(0xFF6A717D)),
               );
-            } else if (!connectionStatus.interNetConnected && model.itemsList.isEmpty) {
+            } else if (!connectionStatus.interNetConnected &&
+                model.itemsList.isEmpty) {
               return NoInternetWidget(
                 onPressed: () async {
                   // ネットワーク接続状態を確認する
@@ -273,7 +271,7 @@ class _FeedPageState extends State<FeedPage> {
                           Expanded(
                             child: ListView.builder(
                               //Listの最新記事取得スクロールの方向が変わる
-                              reverse: true,
+                              // reverse: true,
                               shrinkWrap: true,
                               itemCount: model.itemsList.isNotEmpty
                                   ? model.itemsList.length +
@@ -289,10 +287,9 @@ class _FeedPageState extends State<FeedPage> {
                                     child: Padding(
                                       padding: padding,
                                       child: model.isLoading
-                                          ? const CupertinoActivityIndicator(
-                                              radius: 18,
-                                              color: Color(0xFF6A717D),
-                                            )
+                                          ? const LoadingWidget(
+                                              radius: 18.0,
+                                              color: Color(0xFF6A717D))
                                           : Container(),
                                     ),
                                   );
@@ -311,10 +308,8 @@ class _FeedPageState extends State<FeedPage> {
                   Visibility(
                       visible: model.isLoading && model.itemsList.isEmpty,
                       child: const Center(
-                        child: CupertinoActivityIndicator(
-                          radius: 22,
-                          color: Color(0xFF6A717D),
-                        ),
+                        child: LoadingWidget(
+                            radius: 22.0, color: Color(0xFF6A717D)),
                       )),
                   Visibility(
                     visible: !(model.itemsList.isNotEmpty) &&
@@ -335,7 +330,8 @@ class _FeedPageState extends State<FeedPage> {
   // ListViewに表示する記事がない場合に表示するWidget
 // ListViewに表示する記事がない場合に表示するWidget
   Widget _buildNoResultWidget() {
-    if (!connectionStatus.interNetConnected && feedViewModel.itemsList.isEmpty) {
+    if (!connectionStatus.interNetConnected &&
+        feedViewModel.itemsList.isEmpty) {
       return Container();
     } else {
       return SingleChildScrollView(

--- a/lib/screens/feed_page.dart
+++ b/lib/screens/feed_page.dart
@@ -36,7 +36,7 @@ class _FeedPageState extends State<FeedPage> {
     if (await ConnectionStatus.checkConnectivity()) {
       connectionStatus.interNetConnected = true;
 
-      await feedViewModel.pullQiitaItems();
+      await feedViewModel.pullQiitaItems('feed');
     } else {
       connectionStatus.interNetConnected = false;
     }
@@ -57,7 +57,7 @@ class _FeedPageState extends State<FeedPage> {
     return RefreshIndicator(
       onRefresh: () async {
         // スワイプ時に更新したい処理を書く
-        await feedViewModel.pullQiitaItems();
+        await feedViewModel.pullQiitaItems('feed');
       },
       child: Column(
         children: [
@@ -152,7 +152,9 @@ class _FeedPageState extends State<FeedPage> {
                     },
 
                     // 検索キーワードを更新すると同時に、記事を更新する
-                    onSubmitted: feedViewModel.handleSubmitted,
+                    onSubmitted: (String value) async {
+                      await feedViewModel.handleSubmitted(value);
+                    },
                     decoration: InputDecoration(
                       contentPadding: const EdgeInsets.fromLTRB(30, 7, 0, 7),
                       hintText: 'Search',
@@ -211,14 +213,14 @@ class _FeedPageState extends State<FeedPage> {
                             !model.isLoading &&
                             scrollInfo.metrics.pixels >=
                                 scrollInfo.metrics.maxScrollExtent + 10) {
-                          model.pullQiitaItems();
+                          model.pullQiitaItems('feed');
                         }
 
                         if (Theme.of(context).platform ==
                             TargetPlatform.android) {
                           if (scrollInfo.metrics.pixels ==
                               scrollInfo.metrics.maxScrollExtent) {
-                            model.pullQiitaItems();
+                            model.pullQiitaItems('feed');
                           }
                         }
                         return false;
@@ -269,9 +271,10 @@ class _FeedPageState extends State<FeedPage> {
                             radius: 22.0, color: Color(0xFF6A717D)),
                       )),
                   Visibility(
-                    visible: !(model.itemsList.isNotEmpty) &&
+                    visible: model.itemsList.isEmpty &&
                         !model.isLoading &&
                         !model.firstLoading &&
+                        feedViewModel.searchKeyword.isNotEmpty &&
                         connectionStatus.interNetConnected,
                     child: _buildNoResultWidget(),
                   ),

--- a/lib/screens/feed_page.dart
+++ b/lib/screens/feed_page.dart
@@ -50,8 +50,12 @@ class _FeedPageState extends State<FeedPage> {
   ) {
     final item = feedViewModel.itemsList[index];
     final user = item['user'];
-    final formattedDate =
-        DateFormat('yyyy/MM/dd').format(DateTime.parse(item['created_at']));
+    // 日本標準時に設定
+    final formattedDate = DateFormat('yyyy/MM/dd').format(
+        DateTime.parse(item['created_at'])
+            .toUtc()
+            .add(const Duration(hours: 9)));
+
     final likeCount = item['likes_count'];
 
     return RefreshIndicator(
@@ -211,17 +215,17 @@ class _FeedPageState extends State<FeedPage> {
                       onNotification: (ScrollNotification scrollInfo) {
                         if (!model.isLastPage &&
                             !model.isLoading &&
-                            scrollInfo.metrics.pixels >=
-                                scrollInfo.metrics.maxScrollExtent + 10) {
+                            ((Theme.of(context).platform ==
+                                        TargetPlatform.android &&
+                                    scrollInfo.metrics.atEdge &&
+                                    scrollInfo.metrics.pixels > 0) ||
+                                (Theme.of(context).platform ==
+                                        TargetPlatform.iOS &&
+                                    scrollInfo.metrics.pixels >=
+                                        scrollInfo.metrics.maxScrollExtent +
+                                            5))) {
                           model.pullQiitaItems('feed');
-                        }
-
-                        if (Theme.of(context).platform ==
-                            TargetPlatform.android) {
-                          if (scrollInfo.metrics.pixels ==
-                              scrollInfo.metrics.maxScrollExtent) {
-                            model.pullQiitaItems('feed');
-                          }
+                          print("${Theme.of(context).platform} scroll");
                         }
                         return false;
                       },

--- a/lib/screens/tag_detail_list_page.dart
+++ b/lib/screens/tag_detail_list_page.dart
@@ -1,20 +1,44 @@
 import 'package:flutter/material.dart';
+import '../components/article_list_body.dart';
+import '../main.dart';
 import '../model/tag.dart';
+import '../view_model/feed_view_model.dart';
 
-class TagDetailListPage extends StatelessWidget {
+class TagDetailListPage extends StatefulWidget {
   final Tag tag;
 
   const TagDetailListPage({Key? key, required this.tag}) : super(key: key);
 
   @override
+  State<TagDetailListPage> createState() => _TagDetailListPageState();
+}
+
+class _TagDetailListPageState extends State<TagDetailListPage> {
+  final FeedViewModel feedViewModel = FeedViewModel();
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(tag.name),
-      ),
-      body: const Center(
-        child: Text('タグ詳細ページ'),
-      ),
-    );
+        appBar: !connectionStatus.interNetConnected
+            ? null
+            : AppBar(
+                backgroundColor: Colors.white,
+                automaticallyImplyLeading: false,
+                leading: IconButton(
+                  icon: const Icon(Icons.arrow_back_ios_new_rounded),
+                  iconSize: 28,
+                  color: const Color(0xFF468300),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+                shadowColor: Colors.white.withOpacity(0.3),
+                title: Text(
+                  widget.tag.name,
+                  style: const TextStyle(color: Colors.black, fontSize: 22),
+                ),
+              ),
+        body: ArticleDetailListBody(
+          tag: widget.tag,
+          pageName: 'tag_detail_list',
+        ));
   }
 }

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -23,6 +23,7 @@ class _TagPageState extends State<TagPage> {
     Future(() async {
       await ConnectionStatus.checkConnectivity().then((isConnected) {
         if (isConnected) {
+          tagViewModel.firstLoading = true;
           tagViewModel.fetchTags();
         } else {
           connectionStatus.interNetConnected = false;
@@ -40,6 +41,7 @@ class _TagPageState extends State<TagPage> {
       onPressed: () async {
         if (await ConnectionStatus.checkConnectivity()) {
           connectionStatus.interNetConnected = true;
+          tagViewModel.firstLoading = true;
           tagViewModel.fetchTags();
         } else {
           connectionStatus.interNetConnected = false;
@@ -61,18 +63,17 @@ class _TagPageState extends State<TagPage> {
 
     return NotificationListener<ScrollNotification>(
       onNotification: (scrollInfo) {
-        if (!model.isLastPage &&
-            !model.isLoading &&
-            scrollInfo.metrics.pixels >=
-                scrollInfo.metrics.maxScrollExtent + 5) {
+        if (!model.isLastPage && !model.isLoading &&
+            ((Theme.of(context).platform == TargetPlatform.android &&
+                scrollInfo.metrics.atEdge &&
+                scrollInfo.metrics.pixels > 0) ||
+                (Theme.of(context).platform == TargetPlatform.iOS &&
+                    scrollInfo.metrics.pixels >=
+                        scrollInfo.metrics.maxScrollExtent + 5))) {
           model.fetchTags();
+          print("${Theme.of(context).platform} scroll");
         }
 
-        if (Theme.of(context).platform == TargetPlatform.android) {
-          if (scrollInfo.metrics.pixels == scrollInfo.metrics.maxScrollExtent) {
-            model.fetchTags();
-          }
-        }
         return false;
       },
       child: Padding(
@@ -113,7 +114,7 @@ class _TagPageState extends State<TagPage> {
         value: tagViewModel,
         child: Consumer<TagViewModel>(
           builder: (context, model, child) {
-            if (model.isLoading &&
+            if (model.firstLoading &&
                 model.tags.isEmpty &&
                 connectionStatus.interNetConnected) {
               return _buildInitialLoadingWidget();
@@ -127,10 +128,10 @@ class _TagPageState extends State<TagPage> {
                     visible: model.tags.isNotEmpty,
                     child: _buildTagsGridView(model),
                   ),
-                  Visibility(
-                    visible: model.isLoading && model.tags.isEmpty,
-                    child: _buildInitialLoadingWidget(),
-                  ),
+                  // Visibility(
+                  //   visible: model.isLoading && model.tags.isEmpty,
+                  //   child: _buildInitialLoadingWidget(),
+                  // ),
                 ],
               );
             }

--- a/lib/view_model/feed_view_model.dart
+++ b/lib/view_model/feed_view_model.dart
@@ -14,9 +14,10 @@ class FeedViewModel extends ChangeNotifier {
   bool isLastPage = false;
   List<dynamic> itemsList = [];
   bool firstLoading = true;
+  String pageName = "";
 
   // Qiitaの記事を取得する
-  Future<void> pullQiitaItems() async {
+  Future<void> pullQiitaItems(pageName) async {
     if (!isLastPage) {
       isLoading = true;
       notifyListeners();
@@ -26,6 +27,7 @@ class FeedViewModel extends ChangeNotifier {
         perPage: perPage,
         searchKeyword: searchKeyword,
         isLastPage: isLastPage,
+        pageName: pageName,
       );
 
       if (newItems.isEmpty) {
@@ -46,17 +48,18 @@ class FeedViewModel extends ChangeNotifier {
     firstLoading = false;
   }
 
-  // TextFieldでEnterを押した時に呼ばれる
-  Future<void> searchQiitaItems(String value) async {
+  // Feedページ：TextFieldでEnterを押した時に呼ばれる
+  // Tag詳細ページ：記事を取得する時に呼ばれる
+  Future<void> searchQiitaItems(String value, String pageName) async {
     searchKeyword = value;
     firstLoading = true;
     currentPage = 1;
     isLastPage = false;
     itemsList.clear();
-    await pullQiitaItems();
+    await pullQiitaItems(pageName);
   }
 
-  // TextFieldでEnterを押した時に呼ばれる
+  // FeedページのTextFieldでEnterを押した時に呼ばれる
 
   Future<void> handleSubmitted(String value) async {
     searchKeyword = value;
@@ -64,6 +67,6 @@ class FeedViewModel extends ChangeNotifier {
     currentPage = 1;
     isLastPage = false;
     itemsList.clear();
-    await searchQiitaItems(value);
+    await searchQiitaItems(value, 'feed');
   }
 }

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -8,6 +8,8 @@ class TagViewModel extends ChangeNotifier {
   int _columnCount = 2;
   final QiitaApiService _qiitaApiService = QiitaApiService();
   bool _isLastPage = false;
+
+  // TODO currentPageを追加する
   final int _perPage = 20;
 
   List<Tag> get tags => _tags;

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -8,6 +8,7 @@ class TagViewModel extends ChangeNotifier {
   int _columnCount = 2;
   final QiitaApiService _qiitaApiService = QiitaApiService();
   bool _isLastPage = false;
+  bool _firstLoading = false;
 
   // TODO currentPageを追加する
   final int _perPage = 20;
@@ -16,9 +17,16 @@ class TagViewModel extends ChangeNotifier {
 
   bool get isLoading => _isLoading;
 
+  bool get firstLoading => _firstLoading;
+
   int get columnCount => _columnCount;
 
   bool get isLastPage => _isLastPage;
+
+  set firstLoading(bool value) {
+    _firstLoading = value;
+    notifyListeners();
+  }
 
   Future<void> fetchTags() async {
     if (_isLastPage) {
@@ -31,8 +39,7 @@ class TagViewModel extends ChangeNotifier {
     }
 
     // タグ一覧を取得
-    List<Tag> newTags = await _qiitaApiService.fetchTagList(
-        _perPage, _tags.length ~/ _perPage + 1);
+    List<Tag> newTags = await _qiitaApiService.fetchTagList(_tags.length ~/ _perPage + 1, _perPage);
 
     if (newTags.isEmpty) {
       _isLastPage = true;
@@ -41,6 +48,7 @@ class TagViewModel extends ChangeNotifier {
     // 取得したタグを既存のタグリストに追加
     _tags.addAll(newTags);
     _isLoading = false;
+    _firstLoading = false;
     notifyListeners();
   }
 


### PR DESCRIPTION
**Tag詳細画面の実装**を行いました。
レビューいただけますと幸いです。


## ①実装内容（全体）

- [x] **タグに紐づいたデータ表示→完了**
　https://qiita.com/api/v2/items にクエリを付与してタグの条件に合う記事一覧を表示

- [x] **記事をタップして記事ページを表示→完了**
※Androidでは、WebViewのバグが発生するので、iOS Simulatorでのみ検証を行いました。　#8 

- [x] **ページネーション実装(リストを下まで到達したら追加読み込み)→完了**
<br>


> ↓プレビュー画面（iPhone 14）
> <img src="https://user-images.githubusercontent.com/78660150/227531313-382e8053-c071-4c1a-be5a-9b00fff1808d.gif" width="280px">

<br>

> ↓プレビュー画面（Android）
> <video src="https://user-images.githubusercontent.com/78660150/227538418-4f565c9e-3900-472b-a0a6-87f233828847.webm"></video>


<br>


## ②実装内容（詳細）

**1. Tag詳細ページの作成**
- `lib/screens/tag_detail_list_page.dart`
ArticleDetailListBodyというWidgetで、feedViewModelからタグに関連する記事の一覧を取得し、リストにして表示しています。
<br>

**2. Tag詳細画面用のコンポーネントを追加**
- `lib/components/article_list.dart`
Tag詳細画面（tag_detail_list_page.dart）で表示される記事のリストを構成するためのコンポーネントです。

- `lib/components/article_list_body.dart`
Qiita APIから取得した記事のリストの要素1つ分を表示するためのウィジェット（`ArticleList`） を定義しています。

    > Tag詳細画面（`tag_detail_list_page.dart`）とFeed画面（`feed_page.dart`）で共通利用できるコンポーネントを作成したかったのですが、feedViewModelのstate管理をうまく実装できなかったので、現時点では、Tag詳細画面（`tag_detail_list_page.dart`）でのみ利用できるコンポーネントとなっています。
※Feed画面ではローディング(`LoadingWidget`)と、WebViewを包むモーダル(`customModal`)のみ共通利用しています。
<br>

**3. WebViewを包むモーダルをコンポーネント化**
- `lib/components/custom_modal.dart`
引数で渡された child ウィジェット（`WebViewPage`）をモーダルウィンドウの内容として表示するメソッド（`customModal `）を定義しています。
<br>

**4. Feed画面の共通処理をメソッド化**
- `lib/screens/feed_page.dart`
インターネット接続状態を確認し、その結果に応じた処理を実行するメソッド（`checkConnectivityAndPullItems`）を作成しました。
```dart
  Future<void> checkConnectivityAndPullItems(
      {required FeedViewModel feedViewModel}) async {
    if (await ConnectionStatus.checkConnectivity()) {
      connectionStatus.interNetConnected = true;

      await feedViewModel.pullQiitaItems();
    } else {
      connectionStatus.interNetConnected = false;
    }
```

<br>
