### PR TITLE
11 add pull to refresh

### DIFF
--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -145,8 +145,6 @@ class QiitaApiService {
 
       final data = jsonDecode(response.body);
 
-      // print(response.body);
-
       if (data == null) {
         return [];
       }
@@ -165,7 +163,6 @@ class QiitaApiService {
       //エラーを検知した場合はtrue
       isRequestError = true;
 
-      // print(isRequestError);
       throw Exception('Failed to load tags');
     }
   }

--- a/lib/api/qiita_api_service.dart
+++ b/lib/api/qiita_api_service.dart
@@ -47,10 +47,8 @@ class QiitaApiService {
     }
   }
 
-  // キャッシュのための変数
-  final Map<String, dynamic> cache = {};
-
   Future<List<dynamic>> fetchQiitaItems({
+    // QiitaのAPIから記事一覧・タグ一覧を取得
     required int currentPage,
     required int perPage,
     required String searchKeyword,
@@ -58,11 +56,16 @@ class QiitaApiService {
     required PageName pageName,
   }) async {
     if (!isLastPage) {
+      //デフォルト値をfalseに設定
+      isRequestError = false;
+
       // Qiita APIのエンドポイントURL
       String apiUrl = '';
       switch (pageName) {
         case PageName.feed:
           apiUrl = 'https://qiita.com/api/v2/items';
+          break;
+        case PageName.tags:
           break;
         case PageName.tagDetailList:
           apiUrl = 'https://qiita.com/api/v2/tags/$searchKeyword/items';
@@ -78,54 +81,42 @@ class QiitaApiService {
         url += '&query=$searchKeyword';
       }
 
-      // キャッシュがある場合、キャッシュを使用する
-      if (cache.containsKey(url)) {
-        final List<dynamic> itemsList = cache[url];
-        if (itemsList.length < perPage) {
-          isLastPage = true;
-        }
-        return itemsList;
-      } else {
-        try {
-          late http.Response response;
-          print(accessToken);
-          // Qiita APIにリクエストを送信する
-          response = await http.get(
-            Uri.parse(url),
-            headers: (accessToken != '')
-                ? {
-                    'Authorization': 'Bearer $accessToken',
-                  }
-                : null,
-          );
+      try {
+        late http.Response response;
+        print(accessToken);
+        // Qiita APIにリクエストを送信する
+        response = await http.get(
+          Uri.parse(url),
+          headers: (accessToken != '')
+              ? {
+                  'Authorization': 'Bearer $accessToken',
+                }
+              : null,
+        );
 
-          // レスポンスをパースし、記事のリストを作成する
-          final List<dynamic> newItems = json.decode(response.body);
-          print(url);
+        // print(response.body);
+
+        // レスポンスをパースし、記事のリストを作成する
+        final List<dynamic> newItems = json.decode(response.body);
+        print(url);
+
+        if (newItems.isEmpty) {
+          // 検索結果が見つからなかった場合は、現在の記事リストをクリアして、最初のページから再度取得する
+          isLastPage = true;
+          return [];
+        } else {
+          if (newItems.length < perPage) {
+            isLastPage = true;
+          }
 
           // print(newItems);
-          // キャッシュに記事を追加する
-          cache[url] = newItems;
-
-          // キャッシュのクリア
-          if (cache.length > 10) {
-            cache.remove(cache.keys.first);
-          }
-
-          if (newItems.isEmpty) {
-            // 検索結果が見つからなかった場合は、現在の記事リストをクリアして、最初のページから再度取得する
-            isLastPage = true;
-            return [];
-          } else {
-            if (newItems.length < perPage) {
-              isLastPage = true;
-            }
-            return newItems;
-          }
-        } catch (e) {
-          print('fetchQiitaItems error: $e');
-          return [];
+          return newItems;
         }
+      } catch (e) {
+        //エラーを検知した場合はtrue
+        isRequestError = true;
+
+        print('fetchQiitaItems error: $e');
       }
     }
     return [];
@@ -134,21 +125,28 @@ class QiitaApiService {
   Future<List<Tag>> fetchTagList(int currentPage, int perPage) async {
     // QiitaのAPIからタグ一覧を取得
 
-    late http.Response response;
+    //デフォルト値をfalseに設定
+    isRequestError = false;
 
-    response = await http.get(
-      Uri.parse(
-          'https://qiita.com/api/v2/tags?page=$currentPage&per_page=$perPage&sort=count'),
-      headers: (accessToken != '')
-          ? {
-              'Authorization': 'Bearer $accessToken',
-            }
-          : null,
-    );
-    print(
-        'https://qiita.com/api/v2/tags?page=$currentPage&per_page=$perPage&sort=count');
-    if (response.statusCode == 200) {
+    try {
+      late http.Response response;
+
+      response = await http.get(
+        Uri.parse(
+            'https://qiita.com/api/v2/tags?page=$currentPage&per_page=$perPage&sort=count'),
+        headers: (accessToken != '')
+            ? {
+                'Authorization': 'Bearer $accessToken',
+              }
+            : null,
+      );
+      print(
+          'https://qiita.com/api/v2/tags?page=$currentPage&per_page=$perPage&sort=count');
+
       final data = jsonDecode(response.body);
+
+      // print(response.body);
+
       if (data == null) {
         return [];
       }
@@ -161,8 +159,13 @@ class QiitaApiService {
           itemsCount: tagData['items_count'] ?? 0,
         );
       }).toList();
+
       return tags;
-    } else {
+    } catch (e) {
+      //エラーを検知した場合はtrue
+      isRequestError = true;
+
+      // print(isRequestError);
       throw Exception('Failed to load tags');
     }
   }
@@ -203,6 +206,7 @@ class QiitaApiService {
       followeesCount: response.data['followees_count'] ?? 0,
       followersCount: response.data['followers_count'] ?? 0,
     );
+
     return userData;
   }
 }

--- a/lib/components/api_error_widget.dart
+++ b/lib/components/api_error_widget.dart
@@ -15,7 +15,7 @@ Widget buildApiErrorWidget(context, PageName pageName) {
       heightRatio = 0.158;
       break;
     case PageName.tags:
-      // heightRatio = 0.209;
+      heightRatio = 0.209;
       break;
     case PageName.tagDetailList:
       break;

--- a/lib/components/api_error_widget.dart
+++ b/lib/components/api_error_widget.dart
@@ -26,6 +26,7 @@ Widget buildApiErrorWidget(context, PageName pageName) {
   return Scaffold(
     body: Center(
       child: SingleChildScrollView(
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
         child: Column(
           children: [
             SizedBox(height: deviceHeight * heightRatio),

--- a/lib/components/api_error_widget.dart
+++ b/lib/components/api_error_widget.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import '../model/page_name.dart';
+import '../screens/top_page.dart';
+import 'custom_btn.dart';
+
+Widget buildApiErrorWidget(context, PageName pageName) {
+  // APIリクエストエラー時に表示するウィジェット
+
+  final deviceHeight = MediaQuery.of(context).size.height;
+  final deviceWidth = MediaQuery.of(context).size.width;
+
+  double heightRatio = 0;
+  switch (pageName) {
+    case PageName.feed:
+      heightRatio = 0.158;
+      break;
+    case PageName.tagDetailList:
+      heightRatio = 0.226;
+      break;
+    case PageName.myPage:
+      heightRatio = 0.209;
+      break;
+    case PageName.tags:
+      heightRatio = 0.209;
+      break;
+  }
+
+  return Scaffold(
+    body: Center(
+      child: SingleChildScrollView(
+        child: Column(
+          children: [
+            SizedBox(height: deviceHeight * heightRatio),
+            const SizedBox(
+              height: 66.67,
+              width: 66.67,
+              child: Icon(Icons.error_outline_rounded, size: 48),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'APIリクエストエラー',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: Color(0xFF333333),
+                letterSpacing: -0.24,
+              ),
+            ),
+            const SizedBox(height: 17),
+            const Text(
+              'APIリクエスト回数が上限の６０回を超えました！\n上限を解放するにはログインが必要です。',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                color: Color(0xFF828282),
+                height: 2,
+              ),
+            ),
+            SizedBox(height: deviceHeight * 0.23),
+            SizedBox(
+              width: deviceWidth * 0.85,
+              height: deviceHeight * 0.07,
+              child: CustomButton(
+                onPressed: () async {
+                  //ログイン画面（トップ画面）へ遷移
+                  Navigator.push(context,
+                      MaterialPageRoute(builder: (context) => const TopPage()));
+                },
+                text: 'ログインする',
+                colors: 0xFF74C13A,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/components/api_error_widget.dart
+++ b/lib/components/api_error_widget.dart
@@ -14,14 +14,12 @@ Widget buildApiErrorWidget(context, PageName pageName) {
     case PageName.feed:
       heightRatio = 0.158;
       break;
+    case PageName.tags:
+      // heightRatio = 0.209;
+      break;
     case PageName.tagDetailList:
-      heightRatio = 0.226;
       break;
     case PageName.myPage:
-      heightRatio = 0.209;
-      break;
-    case PageName.tags:
-      heightRatio = 0.209;
       break;
   }
 

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -72,7 +72,7 @@ class ArticleDetailListBodyContentState
     }
   }
 
-  Future _onRefresh() async {
+  Future<void> _onRefresh() async {
     // オーバースクロールされた時に実行する関数を定義
 
     if (_feedViewModel.searchKeyword.isEmpty &&
@@ -85,7 +85,7 @@ class ArticleDetailListBodyContentState
       _feedViewModel.itemsList.clear();
       _feedViewModel.currentPage = 1;
       _feedViewModel.isLastPage = false;
-      fetchItems(_feedViewModel, widget.pageName, widget.tag);
+      await fetchItems(_feedViewModel, widget.pageName, widget.tag);
 
       _buildLists(_feedViewModel);
     }

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -149,7 +149,7 @@ class ArticleDetailListBodyContentState
 
     //タグ詳細ページ、マイページの時は、APIエラーメッセージを表示しない
     final showApiError = (widget.pageName != PageName.tagDetailList ||
-            widget.pageName == PageName.myPage) &&
+            widget.pageName != PageName.myPage) &&
         !model.firstLoading &&
         connectionStatus.interNetConnected &&
         isRequestError;
@@ -215,8 +215,8 @@ class ArticleDetailListBodyContentState
                     Expanded(
                         // pull to refresh（Feedページ専用）
 
-                        child: widget.pageName == PageName.feed
-                        || widget.pageName == PageName.tagDetailList
+                        child: widget.pageName == PageName.feed ||
+                                widget.pageName == PageName.tagDetailList
                             ? RefreshIndicator(
                                 onRefresh: _onRefresh,
                                 child: _buildLists(model))

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -148,7 +148,7 @@ class ArticleDetailListBodyContentState
         connectionStatus.interNetConnected;
 
     //タグ詳細ページ、マイページの時は、APIエラーメッセージを表示しない
-    final showApiError = (widget.pageName != PageName.tagDetailList ||
+    final showApiError = (widget.pageName != PageName.tagDetailList &&
             widget.pageName != PageName.myPage) &&
         !model.firstLoading &&
         connectionStatus.interNetConnected &&

--- a/lib/components/article_list_body.dart
+++ b/lib/components/article_list_body.dart
@@ -103,10 +103,11 @@ class ArticleDetailListBodyContentState
   }
 
   Widget _buildContent(FeedViewModel model) {
-    if (model.firstLoading &&
-        // !model.isLoading &&
+    final showLoad = model.firstLoading &&
         model.itemsList.isEmpty &&
-        widget.pageName != PageName.myPage) {
+        widget.pageName != PageName.myPage;
+
+    if (showLoad) {
       return const LoadingWidget(radius: 18.0, color: Color(0xFF6A717D));
     }
 
@@ -138,6 +139,21 @@ class ArticleDetailListBodyContentState
     profileHeight *= deviceHeight;
 
     print(deviceHeight);
+
+    final showNoResult = widget.pageName == PageName.feed &&
+        !isRequestError &&
+        !model.isLoading &&
+        !model.firstLoading &&
+        model.itemsList.isEmpty &&
+        connectionStatus.interNetConnected;
+
+    //タグ詳細ページ、マイページの時は、APIエラーメッセージを表示しない
+    final showApiError = (widget.pageName != PageName.tagDetailList ||
+            widget.pageName == PageName.myPage) &&
+        !model.firstLoading &&
+        connectionStatus.interNetConnected &&
+        isRequestError;
+
     return RefreshIndicator(
       onRefresh: _onRefresh,
       child: Stack(
@@ -200,6 +216,7 @@ class ArticleDetailListBodyContentState
                         // pull to refresh（Feedページ専用）
 
                         child: widget.pageName == PageName.feed
+                        || widget.pageName == PageName.tagDetailList
                             ? RefreshIndicator(
                                 onRefresh: _onRefresh,
                                 child: _buildLists(model))
@@ -209,19 +226,12 @@ class ArticleDetailListBodyContentState
               ),
             ),
           ),
-          if (widget.pageName == PageName.feed &&
-              !isRequestError &&
-              !model.isLoading &&
-              !model.firstLoading &&
-              model.itemsList.isEmpty &&
-              connectionStatus.interNetConnected)
+          if (showNoResult)
             // 検索結果が見つからない時に表示する（Feedページ限定）
             Stack(
               children: [_buildNoResultWidget()],
             ),
-          if (!model.firstLoading &&
-              connectionStatus.interNetConnected &&
-              isRequestError)
+          if (showApiError)
             //APIリクエストエラーがある時は表示する
             buildApiErrorWidget(context, widget.pageName),
         ],

--- a/lib/components/loading_widget.dart
+++ b/lib/components/loading_widget.dart
@@ -30,7 +30,8 @@ class LoadingWidget extends StatelessWidget {
       );
     }
 
-    return Center(
+    return Align(
+      alignment: !isCircle ? Alignment.topCenter : Alignment.center,
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: indicator,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,9 @@ import '../util/connection_status.dart';
 // インスタンスへの参照を取得
 final connectionStatus = ConnectionStatus();
 
+//API関連のエラーがあるかどうかを判定する
+bool isRequestError = false;
+
 // Qiita APIのアクセストークン
 // アクセストークンを保持するグローバル変数
 late String accessToken;

--- a/lib/model/page_name.dart
+++ b/lib/model/page_name.dart
@@ -1,5 +1,6 @@
 enum PageName {
   feed,
+  tags,
   tagDetailList,
   myPage,
 }

--- a/lib/screens/feed_page.dart
+++ b/lib/screens/feed_page.dart
@@ -53,83 +53,83 @@ class FeedPageState extends State<FeedPage> {
       appBar: !connectionStatus.interNetConnected
           ? null
           : CustomAppBar(
-        title: 'Feed',
-        titleWidget: Column(
-          children: [
-            const Padding(
-              padding: EdgeInsets.only(top: 27, bottom: 19),
-              child: Text(
-                'Feed',
-                style: TextStyle(
-                  fontFamily: 'Pacifico',
-                  fontSize: 17.0,
-                  color: Colors.black,
-                ),
-              ),
-            ),
-            SizedBox(
-              height: 36,
-              width: MediaQuery.of(context).size.width,
-              child: Theme(
-                data: Theme.of(context)
-                    .copyWith(primaryColor: const Color(0xFF74C13A)),
-                child: TextField(
-                  textAlignVertical: TextAlignVertical.center,
-                  style: TextStyle(
-                    color: const Color(0xFF3C3C43).withOpacity(0.6),
-                    fontWeight: FontWeight.w400,
-                    fontSize: 17,
-                    height: 1,
-                    letterSpacing: -0.41,
+              title: 'Feed',
+              titleWidget: Column(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 27, bottom: 19),
+                    child: Text(
+                      'Feed',
+                      style: TextStyle(
+                        fontFamily: 'Pacifico',
+                        fontSize: 17.0,
+                        color: Colors.black,
+                      ),
+                    ),
                   ),
-                  controller: clearController,
-                  onChanged: (value) {
-                    setState(() {
-                      feedViewModel.searchKeyword = value;
-                    });
-                  },
+                  SizedBox(
+                    height: 36,
+                    width: MediaQuery.of(context).size.width,
+                    child: Theme(
+                      data: Theme.of(context)
+                          .copyWith(primaryColor: const Color(0xFF74C13A)),
+                      child: TextField(
+                        textAlignVertical: TextAlignVertical.center,
+                        style: TextStyle(
+                          color: const Color(0xFF3C3C43).withOpacity(0.6),
+                          fontWeight: FontWeight.w400,
+                          fontSize: 17,
+                          height: 1,
+                          letterSpacing: -0.41,
+                        ),
+                        controller: clearController,
+                        onChanged: (value) {
+                          setState(() {
+                            feedViewModel.searchKeyword = value;
+                          });
+                        },
 
-                  // 検索キーワードを更新すると同時に、記事を更新する
-                  onSubmitted: (String value) async {
-                    await feedViewModel.handleSubmitted(value);
-                  },
-                  decoration: InputDecoration(
-                    contentPadding:
-                    const EdgeInsets.fromLTRB(30, 7, 0, 7),
-                    hintText: 'Search',
-                    prefixIcon: const Icon(
-                      Icons.search,
-                      // color: Color(0xFF74C13A)
-                    ),
-                    suffixIcon: feedViewModel.searchKeyword.isNotEmpty
-                        ? IconButton(
-                      onPressed: () {
-                        setState(() {
-                          feedViewModel.searchKeyword = '';
-                        });
-                        clearController.clear();
-                      },
-                      padding: const EdgeInsets.all(0),
-                      icon: const Icon(Icons.clear),
-                      color: Colors.grey,
-                    )
-                        : null,
-                    filled: true,
-                    fillColor: const Color(0xFF767680).withOpacity(0.12),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(10),
-                      borderSide: BorderSide.none,
+                        // 検索キーワードを更新すると同時に、記事を更新する
+                        onSubmitted: (String value) async {
+                          await feedViewModel.handleSubmitted(value);
+                        },
+                        decoration: InputDecoration(
+                          contentPadding:
+                              const EdgeInsets.fromLTRB(30, 7, 0, 7),
+                          hintText: 'Search',
+                          prefixIcon: const Icon(
+                            Icons.search,
+                            // color: Color(0xFF74C13A)
+                          ),
+                          suffixIcon: feedViewModel.searchKeyword.isNotEmpty
+                              ? IconButton(
+                                  onPressed: () {
+                                    setState(() {
+                                      feedViewModel.searchKeyword = '';
+                                    });
+                                    clearController.clear();
+                                  },
+                                  padding: const EdgeInsets.all(0),
+                                  icon: const Icon(Icons.clear),
+                                  color: Colors.grey,
+                                )
+                              : null,
+                          filled: true,
+                          fillColor: const Color(0xFF767680).withOpacity(0.12),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                            borderSide: BorderSide.none,
+                          ),
+                        ),
+                      ),
                     ),
                   ),
-                ),
+                  const SizedBox(
+                    height: 10,
+                  )
+                ],
               ),
             ),
-            const SizedBox(
-              height: 10,
-            )
-          ],
-        ),
-      ),
       body: ChangeNotifierProvider(
           create: (_) => feedViewModel,
           child: const ArticleDetailListBodyContent(

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../components/api_error_widget.dart';
 import '../components/custom_appbar.dart';
 import '../components/loading_widget.dart';
 import '../components/no_internet_widget.dart';
 import '../components/tag_card.dart';
 import '../main.dart';
+import '../model/page_name.dart';
 import '../util/connection_status.dart';
 import '../view_model/tag_view_model.dart';
 
@@ -138,20 +140,32 @@ class _TagPageState extends State<TagPage> {
         child: Consumer<TagViewModel>(
           builder: (context, model, child) {
             if (model.firstLoading &&
-                model.tags.isEmpty &&
+                model.tags.isEmpty && !isRequestError &&
                 connectionStatus.interNetConnected) {
               return _buildInitialLoadingWidget();
             } else if (!connectionStatus.interNetConnected &&
                 model.tags.isEmpty) {
               return _buildNoInternetWidget();
             } else {
+              // return Stack(
+              //   children: [
+              //     Visibility(
+              //       visible: model.tags.isNotEmpty,
+              //       child: _buildTagsGridView(model),
+              //     ),
+              //     if (!model.firstLoading &&
+              //         connectionStatus.interNetConnected &&
+              //         isRequestError)
+              //     //APIリクエストエラーがある時は表示する
+              //       buildApiErrorWidget(context, PageName.tags),
+              //   ],
+              // );
               return Stack(
-                children: [
-                  Visibility(
-                    visible: model.tags.isNotEmpty,
-                    child: _buildTagsGridView(model),
-                  ),
-                ],
+                children: model.isError &&  model.tags.isEmpty
+                    ? [
+                  buildApiErrorWidget(context, PageName.tags)
+                ]
+                    : [_buildTagsGridView(model)],
               );
             }
           },

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -58,14 +58,14 @@ class _TagPageState extends State<TagPage> {
     return const LoadingWidget(radius: 18.0, color: Color(0xFF6A717D));
   }
 
-  Future _onRefresh() async {
+  Future<void> _onRefresh() async {
     // オーバースクロールされた時に実行する関数を定義
 
     //pull to refresh時はページ数、タグリストを初期化して取得し直す
     tagViewModel.tags.clear();
     tagViewModel.firstLoading = true;
     tagViewModel.isLastPage = false;
-    tagViewModel.fetchTags();
+    await tagViewModel.fetchTags();
     _buildTagsGridView(tagViewModel);
   }
 

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -34,7 +34,7 @@ class _TagPageState extends State<TagPage> {
   }
 
   Widget _buildInitialLoadingWidget() {
-    return const LoadingWidget(radius: 22.0, color: Color(0xFF6A717D));
+    return const LoadingWidget(radius: 18.0, color: Color(0xFF6A717D));
   }
 
   Widget _buildNoInternetWidget() {
@@ -55,6 +55,18 @@ class _TagPageState extends State<TagPage> {
   Widget _buildLoadingWidget() {
     return const LoadingWidget(radius: 18.0, color: Color(0xFF6A717D));
   }
+
+  Future _onRefresh() async {
+    // オーバースクロールされた時に実行する関数を定義
+
+      //pull to refresh時はページ数、タグリストを初期化して取得し直す
+      tagViewModel.tags.clear();
+      tagViewModel.firstLoading = true;
+      tagViewModel.isLastPage = false;
+      tagViewModel.fetchTags();
+      _buildTagsGridView(tagViewModel);
+  }
+
 
   Widget _buildTagsGridView(TagViewModel model) {
     final screenWidth = MediaQuery.of(context).size.width;
@@ -81,30 +93,33 @@ class _TagPageState extends State<TagPage> {
         return false;
       },
       child: Padding(
-        padding: const EdgeInsets.only(left: 17, right: 17),
-        child: GridView.builder(
-          shrinkWrap: true,
-          itemCount: model.tags.isNotEmpty
-              ? model.tags.length + (model.isLastPage ? 0 : 1)
-              : 1,
-          itemBuilder: (BuildContext context, int index) {
-            if (index == model.tags.length) {
-              return Padding(
-                padding: EdgeInsets.fromLTRB(paddingLeft, 0, 0, 10),
-                child: SizedBox(
-                  width: MediaQuery.of(context).size.width,
-                  child: _buildLoadingWidget(),
-                ),
-              );
-            } else {
-              return TagCard(tag: model.tags[index]);
-            }
-          },
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            childAspectRatio: 1.0,
-            crossAxisSpacing: 8,
-            mainAxisSpacing: 8,
-            crossAxisCount: crossAxisCount,
+        padding: const EdgeInsets.only(left: 17, right: 17, top: 16),
+        child: RefreshIndicator(
+          onRefresh: _onRefresh,
+          child: GridView.builder(
+            shrinkWrap: true,
+            itemCount: model.tags.isNotEmpty
+                ? model.tags.length + (model.isLastPage ? 0 : 1)
+                : 1,
+            itemBuilder: (BuildContext context, int index) {
+              if (index == model.tags.length) {
+                return Padding(
+                  padding: EdgeInsets.fromLTRB(paddingLeft, 0, 0, 10),
+                  child: SizedBox(
+                    width: MediaQuery.of(context).size.width,
+                    child: _buildLoadingWidget(),
+                  ),
+                );
+              } else {
+                return TagCard(tag: model.tags[index]);
+              }
+            },
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              childAspectRatio: 1.0,
+              crossAxisSpacing: 8,
+              mainAxisSpacing: 8,
+              crossAxisCount: crossAxisCount,
+            ),
           ),
         ),
       ),

--- a/lib/screens/tag_page.dart
+++ b/lib/screens/tag_page.dart
@@ -61,14 +61,13 @@ class _TagPageState extends State<TagPage> {
   Future _onRefresh() async {
     // オーバースクロールされた時に実行する関数を定義
 
-      //pull to refresh時はページ数、タグリストを初期化して取得し直す
-      tagViewModel.tags.clear();
-      tagViewModel.firstLoading = true;
-      tagViewModel.isLastPage = false;
-      tagViewModel.fetchTags();
-      _buildTagsGridView(tagViewModel);
+    //pull to refresh時はページ数、タグリストを初期化して取得し直す
+    tagViewModel.tags.clear();
+    tagViewModel.firstLoading = true;
+    tagViewModel.isLastPage = false;
+    tagViewModel.fetchTags();
+    _buildTagsGridView(tagViewModel);
   }
-
 
   Widget _buildTagsGridView(TagViewModel model) {
     final screenWidth = MediaQuery.of(context).size.width;
@@ -139,32 +138,19 @@ class _TagPageState extends State<TagPage> {
         value: tagViewModel,
         child: Consumer<TagViewModel>(
           builder: (context, model, child) {
-            if (model.firstLoading &&
-                model.tags.isEmpty && !isRequestError &&
-                connectionStatus.interNetConnected) {
+            final showInitialLoad = model.firstLoading &&
+                model.tags.isEmpty &&
+                !isRequestError &&
+                connectionStatus.interNetConnected;
+            if (showInitialLoad) {
               return _buildInitialLoadingWidget();
             } else if (!connectionStatus.interNetConnected &&
                 model.tags.isEmpty) {
               return _buildNoInternetWidget();
             } else {
-              // return Stack(
-              //   children: [
-              //     Visibility(
-              //       visible: model.tags.isNotEmpty,
-              //       child: _buildTagsGridView(model),
-              //     ),
-              //     if (!model.firstLoading &&
-              //         connectionStatus.interNetConnected &&
-              //         isRequestError)
-              //     //APIリクエストエラーがある時は表示する
-              //       buildApiErrorWidget(context, PageName.tags),
-              //   ],
-              // );
               return Stack(
-                children: model.isError &&  model.tags.isEmpty
-                    ? [
-                  buildApiErrorWidget(context, PageName.tags)
-                ]
+                children: model.isError && model.tags.isEmpty
+                    ? [buildApiErrorWidget(context, PageName.tags)]
                     : [_buildTagsGridView(model)],
               );
             }

--- a/lib/screens/top_page.dart
+++ b/lib/screens/top_page.dart
@@ -40,115 +40,116 @@ class _TopPageState extends State<TopPage> {
       deviceHeight = size.height;
     }
 
-    return Scaffold(
-      resizeToAvoidBottomInset: false,
-      body: Stack(
-        alignment: Alignment.topCenter,
-          children: [
-        Container(
-          height: size.height,
-          width: size.width,
-          decoration: BoxDecoration(
-              image: DecorationImage(
-            colorFilter: ColorFilter.mode(
-              Colors.black.withOpacity(imageOpacity),
-              BlendMode.srcATop,
-            ),
-            fit: BoxFit.cover,
-            image: const AssetImage('assets/images/背景画像.png'),
-          )),
-          child: Column(
-            children: [
-              SizedBox(
-                height: deviceHeight * 0.23,
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: Scaffold(
+        resizeToAvoidBottomInset: false,
+        body: Stack(alignment: Alignment.topCenter, children: [
+          Container(
+            height: size.height,
+            width: size.width,
+            decoration: BoxDecoration(
+                image: DecorationImage(
+              colorFilter: ColorFilter.mode(
+                Colors.black.withOpacity(imageOpacity),
+                BlendMode.srcATop,
               ),
-              const Text(
-                'Qiita Feed App',
-                style: TextStyle(
-                  fontFamily: 'Pacifico',
-                  fontSize: 36.0,
-                  color: Color(0xFFFFFFFF),
-                  height: 1,
+              fit: BoxFit.cover,
+              image: const AssetImage('assets/images/背景画像.png'),
+            )),
+            child: Column(
+              children: [
+                SizedBox(
+                  height: deviceHeight * 0.23,
                 ),
-              ),
-              const SizedBox(
-                height: 14,
-              ),
-              const Text(
-                '-PlayGround-',
-                style: TextStyle(
-                    fontSize: 14.0,
-                    fontWeight: FontWeight.w700,
+                const Text(
+                  'Qiita Feed App',
+                  style: TextStyle(
+                    fontFamily: 'Pacifico',
+                    fontSize: 36.0,
                     color: Color(0xFFFFFFFF),
-                    letterSpacing: 0.25,
-                    height: 1),
-              ),
-              SizedBox(
-                height: deviceHeight * 0.45,
-              ),
-              SizedBox(
-                width: deviceWidth * 0.85,
-                height: deviceHeight * 0.07,
-                child: CustomButton(
-                  onPressed: () async {
-                    loadAccessToken();
-                    print(accessToken);
-                    _loadingStart();
-                    if (accessToken == '') {
-                      await customModal(
-                        context,
-                        const WebViewPage(urlString: "isLogIn"),
-                        title: 'Qiita Auth',
-                      );
-                    }
-                    _loadingStop();
-                  },
-                  text: 'ログイン',
-                  colors: 0xFF468300,
+                    height: 1,
+                  ),
                 ),
-              ),
-              SizedBox(
-                width: deviceWidth,
-                height: deviceHeight * 0.1,
-                child: Center(
-                  child: TextButton(
+                const SizedBox(
+                  height: 14,
+                ),
+                const Text(
+                  '-PlayGround-',
+                  style: TextStyle(
+                      fontSize: 14.0,
+                      fontWeight: FontWeight.w700,
+                      color: Color(0xFFFFFFFF),
+                      letterSpacing: 0.25,
+                      height: 1),
+                ),
+                SizedBox(
+                  height: deviceHeight * 0.45,
+                ),
+                SizedBox(
+                  width: deviceWidth * 0.85,
+                  height: deviceHeight * 0.07,
+                  child: CustomButton(
                     onPressed: () async {
-                      //アクセストークンを空文字に設定
-                      await saveAccessToken('');
-                      _toFeed();
+                      loadAccessToken();
+                      print(accessToken);
+                      _loadingStart();
+                      if (accessToken == '') {
+                        await customModal(
+                          context,
+                          const WebViewPage(urlString: "isLogIn"),
+                          title: 'Qiita Auth',
+                        );
+                      }
+                      _loadingStop();
                     },
-                    child: const Text(
-                      'ログインせずに利用する',
-                      style: TextStyle(
-                        fontSize: 14.0,
-                        fontWeight: FontWeight.w700,
-                        color: Color(0xFFFFFFFF),
-                        letterSpacing: 0.75,
-                        height: 1,
+                    text: 'ログイン',
+                    colors: 0xFF468300,
+                  ),
+                ),
+                SizedBox(
+                  width: deviceWidth,
+                  height: deviceHeight * 0.1,
+                  child: Center(
+                    child: TextButton(
+                      onPressed: () async {
+                        //アクセストークンを空文字に設定
+                        await saveAccessToken('');
+                        _toFeed();
+                      },
+                      child: const Text(
+                        'ログインせずに利用する',
+                        style: TextStyle(
+                          fontSize: 14.0,
+                          fontWeight: FontWeight.w700,
+                          color: Color(0xFFFFFFFF),
+                          letterSpacing: 0.75,
+                          height: 1,
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
-              if (isLoading)
-                BackdropFilter(
-                  filter: ImageFilter.blur(
-                    sigmaX: 3,
-                    sigmaY: 3,
+                if (isLoading)
+                  BackdropFilter(
+                    filter: ImageFilter.blur(
+                      sigmaX: 3,
+                      sigmaY: 3,
+                    ),
+                    blendMode: BlendMode.srcOver,
+                    child: Container(),
                   ),
-                  blendMode: BlendMode.srcOver,
-                  child: Container(),
-                ),
-            ],
+              ],
+            ),
           ),
-        ),
-        if (isLoading)
-          Padding(
-            padding: EdgeInsets.only(top: deviceHeight * 0.06),
-            child: const CupertinoActivityIndicator(
-                radius: 15.0, color: CupertinoColors.white),
-          ),
-      ]),
+          if (isLoading)
+            Padding(
+              padding: EdgeInsets.only(top: deviceHeight * 0.06),
+              child: const CupertinoActivityIndicator(
+                  radius: 15.0, color: CupertinoColors.white),
+            ),
+        ]),
+      ),
     );
   }
 

--- a/lib/screens/top_page.dart
+++ b/lib/screens/top_page.dart
@@ -91,7 +91,7 @@ class _TopPageState extends State<TopPage> {
                   height: deviceHeight * 0.07,
                   child: CustomButton(
                     onPressed: () async {
-                      loadAccessToken();
+                      await loadAccessToken();
                       print(accessToken);
                       _loadingStart();
                       if (accessToken == '') {

--- a/lib/view_model/feed_view_model.dart
+++ b/lib/view_model/feed_view_model.dart
@@ -47,6 +47,7 @@ class FeedViewModel extends ChangeNotifier {
       notifyListeners();
     }
     firstLoading = false;
+    notifyListeners();
   }
 
   // Feedページ：TextFieldでEnterを押した時に呼ばれる

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -1,5 +1,6 @@
 import '../api/qiita_api_service.dart';
 import 'package:flutter/material.dart';
+import '../main.dart';
 import '../model/tag.dart';
 
 class TagViewModel extends ChangeNotifier {
@@ -9,6 +10,7 @@ class TagViewModel extends ChangeNotifier {
   final QiitaApiService _qiitaApiService = QiitaApiService();
   bool _isLastPage = false;
   bool _firstLoading = false;
+  bool _isError = false;
   final int _perPage = 20;
 
   List<Tag> get tags => _tags;
@@ -21,6 +23,8 @@ class TagViewModel extends ChangeNotifier {
 
   bool get isLastPage => _isLastPage;
 
+  bool get isError => _isError;
+
   set firstLoading(bool value) {
     _firstLoading = value;
     notifyListeners();
@@ -31,6 +35,10 @@ class TagViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  set isError(bool value) {
+    _isError = value;
+    notifyListeners();
+  }
 
   Future<void> fetchTags() async {
     if (_isLastPage) {
@@ -42,6 +50,17 @@ class TagViewModel extends ChangeNotifier {
       notifyListeners();
     }
 
+    if(isRequestError){
+      print("error detected");
+      _isError = true;
+      _firstLoading = false;
+      notifyListeners();
+    } else {
+      print("error no detected");
+      _isError = false;
+      notifyListeners();
+    }
+
     // タグ一覧を取得
     List<Tag> newTags = await _qiitaApiService.fetchTagList(
         _tags.length ~/ _perPage + 1, _perPage);
@@ -49,6 +68,7 @@ class TagViewModel extends ChangeNotifier {
     if (newTags.isEmpty) {
       _isLastPage = true;
     }
+
 
     // 取得したタグを既存のタグリストに追加
     _tags.addAll(newTags);

--- a/lib/view_model/tag_view_model.dart
+++ b/lib/view_model/tag_view_model.dart
@@ -26,6 +26,12 @@ class TagViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  set isLastPage(bool value) {
+    _isLastPage = value;
+    notifyListeners();
+  }
+
+
   Future<void> fetchTags() async {
     if (_isLastPage) {
       return;


### PR DESCRIPTION
<br>

#### [テスト仕様書](https://docs.google.com/spreadsheets/d/1sCpuqo_1BHFMCG8V6U7AuLHymIm13V5eNGUoxPv6JU8/edit#gid=0)に基づき、いくつか機能追加を行いました。
#### 差分が多くなってしまい、恐縮ですが、レビューいただけますと幸いです。

<br>

## ①実装内容

**1. pull to refresh機能を追加<br>
2. キーボード自動close機能を追加<br>
3. APIリクエストエラーメッセージを表示する機能を追加**

<br>

## ②実装詳細（機能ごと）

### pull to refresh機能

- Feedページ、タグ一覧ページ、マイページにpull to refresh機能を追加しました。
※Feedページには、**検索結果0件の状態でテキストフィールドを空にしてPullToRefreshする機能**を追加しました。

<br>

`プレビュー（Feedページ）`
![feed_pull_to_refresh](https://user-images.githubusercontent.com/78660150/230750664-ee882008-4036-447a-af0f-59e196f4bca5.gif)

`プレビュー（タグ一覧・マイページ）`
![tagpage_mypage_pull_to_refresh_](https://user-images.githubusercontent.com/78660150/230750768-21d23cb9-c516-44f4-869b-ef0a801b1b8a.gif)


#### `lib/components/article_list_body.dart`、`lib/screens/tag_page.dart`
- pull to refreshを実現するために、リストを初期化&1ページ目から要素を再取得する処理を追加しました。

#### `lib/components/loading_widget.dart`
- ローディングアイコンのサイズを変更しました。

<hr>

### キーボード自動close機能

- キーボード表示中に下記の操作を行った時に、キーボードを閉じるように設定しました。

> 1. 記事リストをスクロールした時
> 2. 検索結果が見つからなかった時に表示するWidgetをスクロールした時

`プレビュー`
![keyboard_close](https://user-images.githubusercontent.com/78660150/230750705-f31a1aaa-53da-4ac2-9c93-aa4171b45e4b.gif)

#### `lib/components/article_list_body.dart`
- SingleChildScrollView や ListView などのスクロール可能な Widgetに、下記のプロパティと値を追加しました。
`keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag`

<hr>

### APIリクエストエラーメッセージを表示する機能

- APIリクエストを送り、エラーメッセージを取得した時に、APIリクエストに関するエラーメッセージを表示する機能を追加しました。

<br>

`実装イメージ`
<img width="300" src="https://user-images.githubusercontent.com/78660150/230750668-60ec987e-2ba8-495e-9843-628c1ad276c4.png">

`プレビュー`
![api_error](https://user-images.githubusercontent.com/78660150/230750725-49af093a-4830-40a7-ba28-aa67d26a6b0d.gif)

下記の流れでプレビューを撮影しています。

```
APIリクエスト制限状態（60回ほどリクエストした後）
→時間経過により、制限解除
→もう一度60回ほどリクエスト
→APIエラーメッセージを表示
※HTTPリクエストを送り、エラーメッセージを受け取った場合は、APIリクエスト関連のエラーメッセージを表示するWidgetを描画するように設定しました。
```

#### `lib/main.dart`
- エラー状態を監視するための変数（`isRequestError`）を追加しました。

#### `lib/components/article_list_body.dart`、`lib/screens/tag_page.dart`
- 記事やタグの一覧を取得するためのメソッドを実行し、エラーメッセージを受け取った場合には、`buildApiErrorWidget`を表示するように設定しました。

#### `lib/model/page_name.dart`
- enumにtagsを追加

#### `lib/components/api_error_widget.dart`
- APIエラーメッセージを表示するためのWidgetを返すメソッドを実装しました。
- トップ画面に戻る機能を追加しました。

#### `lib/view_model/feed_view_model.dart`
- 変数`firstLoading` の変更内容を通知できるように設定しました。`lib/view_model/tag_view_model.dart`

#### `lib/api/qiita_api_service.dart`
- エラーハンドリングを行うために、try-catch 構文に変更しました。

#### `lib/screens/top_page.dart`
- 「ログインする」ボタンを押した後、トップ画面からバックスクロールできないように、`WillPopScope`を追加しました。

<hr>

### その他

#### `lib/screens/feed_page.dart`
- Android Studioでフォーマットをかけて、インデントの調整を行いました。

<br>